### PR TITLE
Update version to 2.0.2 and enhance Country type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yusifaliyevpro/countries",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "publishConfig": {
     "access": "public"
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,7 +26,7 @@ type TranslationValue = { official: string; common: string };
 type Translations = Partial<Record<SupportedLanguages, TranslationValue>> & Record<string, TranslationValue>;
 
 export type Country = {
-  name: { common: string; official: string; nativeName?: { [key: string]: { official: string; common: string } } };
+  name: { common: string; official: string; nativeName?: Record<string, { official: string; common: string }> };
   tld?: string[];
   cca2: string;
   ccn3?: string;
@@ -35,19 +35,19 @@ export type Country = {
   independent: boolean;
   status: string;
   unMember: boolean;
-  currencies?: { [key: string]: { name: string; symbol: string } };
+  currencies?: Record<string, { name: string; symbol: string }>;
   idd: { root: string; suffixes: string[] } | Record<string, never>;
   capital?: string[];
   altSpellings: string[];
   region: string;
   subregion?: string;
-  languages?: { [key: string]: string };
+  languages?: Record<string, string>;
   translations: Translations;
   latlng: [number, number];
   landlocked: boolean;
   borders?: string[];
   area: number;
-  demonyms: { [key: string]: { f: string; m: string } };
+  demonyms: Record<string, { f: string; m: string }>;
   flag: string;
   maps: { googleMaps: string; openStreetMaps: string };
   population: number;


### PR DESCRIPTION
Bump the package version to 2.0.2 and improve the clarity of Country type definitions by replacing index signatures with more explicit Record types.