### PR TITLE
Enhance getCountries function documentation and error logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yusifaliyevpro/countries",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "publishConfig": {
     "access": "public"
   },

--- a/src/functions/getCountries.ts
+++ b/src/functions/getCountries.ts
@@ -5,7 +5,8 @@ import { Country, CountryPicker } from "../types";
  * Fetches all countries, optionally filtered by independence status,
  * and including only the specified fields.
  *
- * > **Note:** The `fields` parameter is required, as mandated by Alejandro Matos See: {@link https://gitlab.com/restcountries/restcountries/-/issues/265}.
+ * > **Note:** The `fields` parameter is required and you can only specify upto 10 fields,
+ * as mandated by Alejandro Matos See: {@link https://gitlab.com/restcountries/restcountries/-/issues/265}.
  *
  * @param params - An object containing:
  *   - `fields`: A required array of field names (keys from the `Country` type) to include in the response.
@@ -27,11 +28,12 @@ import { Country, CountryPicker } from "../types";
  *   fields: ["name", "area"]
  * });
  */
-export async function getCountries<T extends readonly (keyof Country)[]>(
+export async function getCountries<T extends readonly (keyof Country)[] & { length: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 }>(
   { independent, fields }: { independent?: boolean; fields: T },
   fetchOptions?: RequestInit
 ): Promise<CountryPicker<T>[] | null> {
   try {
+    if (fields.length > 10) console.error("You can specify up to 10 fields only");
     const api = constructAPI({ status: independent, fields });
     const response = await fetch(api.toString(), fetchOptions);
     handleNotFoundError(response.ok);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -27,7 +27,9 @@ export function constructAPI({ route = "all", query = "", fields, status, codes,
 
 export function handleNotFoundError(ok: boolean) {
   if (!ok)
-    console.log("Couldn't find any country that matches your query, if you think it is issue please submit it via github issues");
+    console.error(
+      "Couldn't find any country that matches your query, if you think it is issue please submit it via github issues"
+    );
 }
 
 export function handleNetworkError(error: any) {


### PR DESCRIPTION
Improve documentation for the `getCountries` function by specifying a limit of 10 fields. Update error logging in the `handleNotFoundError` function to use `console.error` for better visibility of issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enforced a limit of up to 10 fields when requesting country data, with improved error logging and clearer documentation.
  - Enhanced error logging for not found errors to provide clearer feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->