### PR TITLE
Update Node.js version and refactor imports

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: "20"
+          node-version: "24"
       - run: npm install -g pnpm
       - run: pnpm install
       - run: pnpm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yusifaliyevpro/countries",
   "description": "TypeScript wrapper for Rest Countries API to fetch country data by codes, capitals, or all countries with full typings.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": "MIT",
   "type": "module",
   "author": {
@@ -24,10 +24,10 @@
     "@types/node": "^22.15.34",
     "jest": "^30.3.0",
     "prettier": "^3.8.1",
-    "ts-jest": "^29.4.6",
+    "ts-jest": "^29.4.9",
     "ts-node": "^10.9.2",
-    "tsdown": "^0.21.4",
-    "typescript": "^5.9.3"
+    "tsdown": "^0.21.7",
+    "typescript": "^6.0.2"
   },
   "keywords": [
     "countries",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,22 +16,22 @@ importers:
         version: 22.15.34
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@22.15.34)(ts-node@10.9.2(@types/node@22.15.34)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.15.34)(ts-node@10.9.2(@types/node@22.15.34)(typescript@6.0.2))
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
       ts-jest:
-        specifier: ^29.4.6
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.15.34)(ts-node@10.9.2(@types/node@22.15.34)(typescript@5.9.3)))(typescript@5.9.3)
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.15.34)(ts-node@10.9.2(@types/node@22.15.34)(typescript@6.0.2)))(typescript@6.0.2)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.15.34)(typescript@5.9.3)
+        version: 10.9.2(@types/node@22.15.34)(typescript@6.0.2)
       tsdown:
-        specifier: ^0.21.4
-        version: 0.21.7(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(synckit@0.11.12)(typescript@5.9.3)
+        specifier: ^0.21.7
+        version: 0.21.7(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(synckit@0.11.12)(typescript@6.0.2)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
 
 packages:
 
@@ -429,36 +429,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
@@ -600,41 +606,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -999,8 +1013,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -1575,8 +1589,8 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
-  ts-jest@29.4.6:
-    resolution: {integrity: sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==}
+  ts-jest@29.4.9:
+    resolution: {integrity: sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -1587,7 +1601,7 @@ packages:
       esbuild: '*'
       jest: ^29.0.0 || ^30.0.0
       jest-util: ^29.0.0 || ^30.0.0
-      typescript: '>=4.3 <6'
+      typescript: '>=4.3 <7'
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -1659,8 +1673,8 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2017,7 +2031,7 @@ snapshots:
       jest-util: 30.3.0
       slash: 3.0.0
 
-  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@22.15.34)(typescript@5.9.3))':
+  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@22.15.34)(typescript@6.0.2))':
     dependencies:
       '@jest/console': 30.3.0
       '@jest/pattern': 30.0.1
@@ -2032,7 +2046,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@22.15.34)(ts-node@10.9.2(@types/node@22.15.34)(typescript@5.9.3))
+      jest-config: 30.3.0(@types/node@22.15.34)(ts-node@10.9.2(@types/node@22.15.34)(typescript@6.0.2))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -2766,7 +2780,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  handlebars@4.7.8:
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2
@@ -2880,15 +2894,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@22.15.34)(ts-node@10.9.2(@types/node@22.15.34)(typescript@5.9.3)):
+  jest-cli@30.3.0(@types/node@22.15.34)(ts-node@10.9.2(@types/node@22.15.34)(typescript@6.0.2)):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.15.34)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.15.34)(typescript@6.0.2))
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@22.15.34)(ts-node@10.9.2(@types/node@22.15.34)(typescript@5.9.3))
+      jest-config: 30.3.0(@types/node@22.15.34)(ts-node@10.9.2(@types/node@22.15.34)(typescript@6.0.2))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -2899,7 +2913,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.3.0(@types/node@22.15.34)(ts-node@10.9.2(@types/node@22.15.34)(typescript@5.9.3)):
+  jest-config@30.3.0(@types/node@22.15.34)(ts-node@10.9.2(@types/node@22.15.34)(typescript@6.0.2)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -2926,7 +2940,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.15.34
-      ts-node: 10.9.2(@types/node@22.15.34)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@22.15.34)(typescript@6.0.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -3187,12 +3201,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@22.15.34)(ts-node@10.9.2(@types/node@22.15.34)(typescript@5.9.3)):
+  jest@30.3.0(@types/node@22.15.34)(ts-node@10.9.2(@types/node@22.15.34)(typescript@6.0.2)):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.15.34)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.15.34)(typescript@6.0.2))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@22.15.34)(ts-node@10.9.2(@types/node@22.15.34)(typescript@5.9.3))
+      jest-cli: 30.3.0(@types/node@22.15.34)(ts-node@10.9.2(@types/node@22.15.34)(typescript@6.0.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -3366,7 +3380,7 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.12(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0))(typescript@5.9.3):
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.12(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0))(typescript@6.0.2):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3
@@ -3380,7 +3394,7 @@ snapshots:
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.12(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -3501,18 +3515,18 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.15.34)(ts-node@10.9.2(@types/node@22.15.34)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.15.34)(ts-node@10.9.2(@types/node@22.15.34)(typescript@6.0.2)))(typescript@6.0.2):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.8
-      jest: 30.3.0(@types/node@22.15.34)(ts-node@10.9.2(@types/node@22.15.34)(typescript@5.9.3))
+      handlebars: 4.7.9
+      jest: 30.3.0(@types/node@22.15.34)(ts-node@10.9.2(@types/node@22.15.34)(typescript@6.0.2))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.7.4
       type-fest: 4.41.0
-      typescript: 5.9.3
+      typescript: 6.0.2
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.29.0
@@ -3521,7 +3535,7 @@ snapshots:
       babel-jest: 30.3.0(@babel/core@7.29.0)
       jest-util: 30.3.0
 
-  ts-node@10.9.2(@types/node@22.15.34)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@22.15.34)(typescript@6.0.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -3535,11 +3549,11 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 5.9.3
+      typescript: 6.0.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  tsdown@0.21.7(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(synckit@0.11.12)(typescript@5.9.3):
+  tsdown@0.21.7(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(synckit@0.11.12)(typescript@6.0.2):
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
@@ -3550,7 +3564,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.12(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.12(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0))(typescript@5.9.3)
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.12(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0))(typescript@6.0.2)
       semver: 7.7.4
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
@@ -3558,7 +3572,7 @@ snapshots:
       unconfig-core: 7.5.0
       unrun: 0.2.34(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(synckit@0.11.12)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -3577,7 +3591,7 @@ snapshots:
 
   type-fest@4.41.0: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   uglify-js@3.19.3:
     optional: true

--- a/src/functions/getCountries.ts
+++ b/src/functions/getCountries.ts
@@ -1,5 +1,5 @@
 import { constructAPI, handleNetworkError, handleNotFoundError } from "../helpers";
-import { Country, CountryPicker } from "../types";
+import type { Country, CountryPicker } from "../types";
 
 /**
  * Fetches all countries, optionally filtered by independence status,

--- a/src/functions/getCountriesByCodes.ts
+++ b/src/functions/getCountriesByCodes.ts
@@ -1,6 +1,6 @@
 import { constructAPI, handleNetworkError } from "../helpers";
-import { Country, CountryPicker } from "../types";
-import { Code } from "../types/common";
+import type { Country, CountryPicker } from "../types";
+import type { Code } from "../types/common";
 
 /**
  * Fetches countries by their codes (e.g., CCA2, CCA3, or CIOC), optionally including only the specified fields.

--- a/src/functions/getCountriesByCurrency.ts
+++ b/src/functions/getCountriesByCurrency.ts
@@ -1,5 +1,5 @@
 import { constructAPI, handleNetworkError } from "../helpers";
-import { Country, CountryPicker, Currency } from "../types";
+import type { Country, CountryPicker, Currency } from "../types";
 
 /**
  * Fetches countries that use the specified currency, optionally including only the specified fields.

--- a/src/functions/getCountriesByLang.ts
+++ b/src/functions/getCountriesByLang.ts
@@ -1,5 +1,5 @@
 import { constructAPI, handleNetworkError } from "../helpers";
-import { Country, CountryPicker, Lang } from "../types";
+import type { Country, CountryPicker, Lang } from "../types";
 
 /**
  * Fetches countries where the specified language is officially or widely spoken,

--- a/src/functions/getCountriesByName.ts
+++ b/src/functions/getCountriesByName.ts
@@ -1,5 +1,5 @@
 import { constructAPI, handleNetworkError } from "../helpers";
-import { Country, CountryPicker } from "../types";
+import type { Country, CountryPicker } from "../types";
 
 /**
  * Fetches countries that match a given name or partial name,

--- a/src/functions/getCountriesByRegion.ts
+++ b/src/functions/getCountriesByRegion.ts
@@ -1,5 +1,5 @@
 import { constructAPI, handleNetworkError, handleNotFoundError } from "../helpers";
-import { Country, CountryPicker, Region } from "../types";
+import type { Country, CountryPicker, Region } from "../types";
 
 /**
  * Fetches countries which belong to the specified world region,

--- a/src/functions/getCountriesBySubregion.ts
+++ b/src/functions/getCountriesBySubregion.ts
@@ -1,5 +1,5 @@
 import { constructAPI, handleNetworkError } from "../helpers";
-import { Country, CountryPicker, Subregion } from "../types";
+import type { Country, CountryPicker, Subregion } from "../types";
 
 /**
  * Fetches countries that belong to the specified subregion,

--- a/src/functions/getCountryByCapital.ts
+++ b/src/functions/getCountryByCapital.ts
@@ -1,5 +1,5 @@
 import { constructAPI, handleNetworkError } from "../helpers";
-import { Capital, Country, CountryPicker } from "../types";
+import type { Capital, Country, CountryPicker } from "../types";
 
 /**
  * Fetches a single country by its capital city,

--- a/src/functions/getCountryByCode.ts
+++ b/src/functions/getCountryByCode.ts
@@ -1,6 +1,6 @@
 import { constructAPI, handleNetworkError } from "../helpers";
-import { Country, CountryPicker } from "../types";
-import { Code } from "../types/common";
+import type { Country, CountryPicker } from "../types";
+import type { Code } from "../types/common";
 
 /**
  * Fetches a single country by its code (e.g., CCA2, CCA3, or CIOC),

--- a/src/functions/getCountryByDemonym.ts
+++ b/src/functions/getCountryByDemonym.ts
@@ -1,5 +1,5 @@
 import { constructAPI, handleNetworkError } from "../helpers";
-import { Country, CountryPicker } from "../types";
+import type { Country, CountryPicker } from "../types";
 
 /**
  * Fetches a single country by its demonym (the name for its residents),

--- a/src/functions/getCountryByTranslation.ts
+++ b/src/functions/getCountryByTranslation.ts
@@ -1,5 +1,5 @@
 import { constructAPI, handleNetworkError } from "../helpers";
-import { Country, CountryPicker } from "../types";
+import type { Country, CountryPicker } from "../types";
 
 /**
  * Fetches a single country by a translated country name,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,6 +1,6 @@
 import { API_BASE_URL } from "./constants";
 import { routes } from "./data/api-routes";
-import { Country } from "./types";
+import type { Country } from "./types";
 
 type Route = (typeof routes)[number];
 export type ConstructAPI = {
@@ -12,7 +12,7 @@ export type ConstructAPI = {
   fullText?: boolean;
 };
 
-export function constructAPI({ route = "all", query = "", fields, status, codes, fullText }: ConstructAPI) {
+export function constructAPI({ route = "all", query = "", fields, status, codes, fullText }: ConstructAPI): URL {
   const base_url = new URL(API_BASE_URL);
   if (status !== undefined) route = "independent";
 
@@ -25,14 +25,14 @@ export function constructAPI({ route = "all", query = "", fields, status, codes,
   return base_url;
 }
 
-export function handleNotFoundError(ok: boolean) {
+export function handleNotFoundError(ok: boolean): void {
   if (!ok)
     console.error(
       "Couldn't find any country that matches your query, if you think it is issue please submit it via github issues",
     );
 }
 
-export function handleNetworkError(error: any) {
+export function handleNetworkError(error: any): void {
   console.warn("A network or REST Countries API side error happened while fetching data. Try again later.");
   console.warn(
     "If this error persists, please verify the status of the REST Countries API. If the issue continues, feel free to report it on GitHub: https://github.com/yusifaliyevpro/countries",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-import { Country } from "./types";
+import type { Country } from "./types";
 // import { getCountries } from "./functions/getCountries";
 
-export const defineFields = <T extends (keyof Country)[]>(fields: readonly [...T]) => fields;
+export const defineFields = <T extends (keyof Country)[]>(fields: readonly [...T]): readonly [...T] => fields;
 
 export { getCountries } from "./functions/getCountries";
 export { getCountriesByCodes } from "./functions/getCountriesByCodes";

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,4 +1,4 @@
-import { Cca2Code, Cca3Code, Ccn3Code, CiocCode } from ".";
+import type { Cca2Code, Cca3Code, Ccn3Code, CiocCode } from ".";
 
 export type LiteralUnion<T> = T | (string & {});
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,13 +1,13 @@
-import { capitals } from "../data/capitals";
-import { cca2Codes } from "../data/cca2.codes";
-import { cca3Codes } from "../data/cca3.codes";
-import { ccn3Codes } from "../data/ccn3";
-import { ciocCodes } from "../data/cioc";
-import { currencies } from "../data/currencies";
-import { languages, supportedLanguages } from "../data/langs";
-import { regions } from "../data/regions";
-import { subregions } from "../data/subregions";
-import { LiteralUnion } from "./common";
+import type { capitals } from "../data/capitals";
+import type { cca2Codes } from "../data/cca2.codes";
+import type { cca3Codes } from "../data/cca3.codes";
+import type { ccn3Codes } from "../data/ccn3";
+import type { ciocCodes } from "../data/cioc";
+import type { currencies } from "../data/currencies";
+import type { languages, supportedLanguages } from "../data/langs";
+import type { regions } from "../data/regions";
+import type { subregions } from "../data/subregions";
+import type { LiteralUnion } from "./common";
 
 export type CountryPicker<T extends readonly (keyof Country)[]> = Pick<Country, T[number]>;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,15 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "Preserve",
     "moduleResolution": "Bundler",
-    "declaration": false,
+    "declaration": true,
     "strict": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
+    "isolatedDeclarations": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node", "jest"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Upgrade Node.js to version 24 and update dependencies. Refactor imports to use `import type` for better type safety and clarity.

## Summary

This PR updates the Node.js version and refactors import statements to enhance type safety.

## Changes

- Updated Node.js version to 24.
- Refactored imports to use `import type`.

## Checklist

- [ ] Ran `pnpm checks` locally
- [ ] No hardcoded secrets or API keys



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 2.3.1.
  * Updated development dependencies: TypeScript, ts-jest, and tsdown to latest compatible versions.
  * Updated CI/CD workflows to use Node.js 24 for build and test processes.
  * Enhanced TypeScript configuration with declaration file generation and ES2022 target support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->