### PR TITLE
Update README for v5 migration and enhance type validation

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,5 @@
 pnpm-lock.yaml
 pnpm-workspace.yaml
 node_modules
-README.md
 AGENTS.md
 dist

--- a/README.MD
+++ b/README.MD
@@ -63,46 +63,46 @@ new RestCountries({
 
 v5 restructured the schema. Use this table to translate the `fields` you used to request and the properties you read off each country. Because `fields` selects at **top-level key granularity**, the "Request field" column is what you pass to `fields`; the "Read it as" column is the property path on the returned object.
 
-| v2 field | Request field (v5) | Read it as (v5) | Notes |
-| --- | --- | --- | --- |
-| `name` | `names` | `names.common`, `names.official` | |
-| `name.nativeName` | `names` | `names.native` | keyed by language code |
-| `altSpellings` | `names` | `names.alternates` | |
-| `translations` | `names` | `names.translations` | |
-| `cca2` | `codes` | `codes.alpha_2` | |
-| `cca3` | `codes` | `codes.alpha_3` | |
-| `ccn3` | `codes` | `codes.ccn3` | |
-| `cioc` | `codes` | `codes.cioc` | |
-| `fifa` | `codes` | `codes.fifa` | |
-| `capital` | `capitals` | `capitals[].name` | now objects: `{ name, coordinates, attributes }` |
-| `capitalInfo.latlng` | `capitals` | `capitals[].coordinates` | `{ lat, lng }` |
-| `latlng` | `coordinates` | `coordinates.lat`, `coordinates.lng` | tuple → object |
-| `region` | `region` | `region` | unchanged |
-| `subregion` | `subregion` | `subregion` | unchanged |
-| `continents` | `continents` | `continents` | unchanged |
-| `borders` | `borders` | `borders` | unchanged |
-| `landlocked` | `landlocked` | `landlocked` | unchanged |
-| `area` | `area` | `area.kilometers`, `area.miles` | number → object |
-| `population` | `population` | `population` | unchanged |
-| `timezones` | `timezones` | `timezones` | unchanged |
-| `independent` | `classification` | `classification.sovereign` | closest match; see note below |
-| `unMember` | `classification` | `classification.un_member` | |
-| `status` | `classification` | `classification.iso_status` | e.g. `"official"` |
-| `currencies` | `currencies` | `currencies[]` | `Record` → array of `{ code, name, symbol }` |
-| `languages` | `languages` | `languages[].name` | `Record` → array of language objects |
-| `demonyms` | `demonyms` | `demonyms` | shape unchanged (`{ [lang]: { f, m } }`) |
-| `car.side` | `cars` | `cars.driving_side` | renamed |
-| `car.signs` | `cars` | `cars.signs` | |
-| `tld` | `tlds` | `tlds` | renamed |
-| `idd` | `calling_codes` | `calling_codes` | `{ root, suffixes }` → `string[]` |
-| `flag` (emoji) | `flag` | `flag.emoji` | `flag` is now an object |
-| `flags.png` / `flags.svg` | `flag` | `flag.url_png`, `flag.url_svg` | |
-| `flags.alt` | `flag` | `flag.description` | |
-| `maps.googleMaps` | `links` | `links.google_maps` | |
-| `maps.openStreetMaps` | `links` | `links.open_street_maps` | |
-| `gini` | `economy` | `economy.gini_coefficient` | |
-| `startOfWeek` | `date` | `date.start_of_week` | |
-| `postalCode` | `postal_code` | `postal_code.format`, `postal_code.regex` | renamed |
+| v2 field                  | Request field (v5) | Read it as (v5)                           | Notes                                            |
+| ------------------------- | ------------------ | ----------------------------------------- | ------------------------------------------------ |
+| `name`                    | `names`            | `names.common`, `names.official`          |                                                  |
+| `name.nativeName`         | `names`            | `names.native`                            | keyed by language code                           |
+| `altSpellings`            | `names`            | `names.alternates`                        |                                                  |
+| `translations`            | `names`            | `names.translations`                      |                                                  |
+| `cca2`                    | `codes`            | `codes.alpha_2`                           |                                                  |
+| `cca3`                    | `codes`            | `codes.alpha_3`                           |                                                  |
+| `ccn3`                    | `codes`            | `codes.ccn3`                              |                                                  |
+| `cioc`                    | `codes`            | `codes.cioc`                              |                                                  |
+| `fifa`                    | `codes`            | `codes.fifa`                              |                                                  |
+| `capital`                 | `capitals`         | `capitals[].name`                         | now objects: `{ name, coordinates, attributes }` |
+| `capitalInfo.latlng`      | `capitals`         | `capitals[].coordinates`                  | `{ lat, lng }`                                   |
+| `latlng`                  | `coordinates`      | `coordinates.lat`, `coordinates.lng`      | tuple → object                                   |
+| `region`                  | `region`           | `region`                                  | unchanged                                        |
+| `subregion`               | `subregion`        | `subregion`                               | unchanged                                        |
+| `continents`              | `continents`       | `continents`                              | unchanged                                        |
+| `borders`                 | `borders`          | `borders`                                 | unchanged                                        |
+| `landlocked`              | `landlocked`       | `landlocked`                              | unchanged                                        |
+| `area`                    | `area`             | `area.kilometers`, `area.miles`           | number → object                                  |
+| `population`              | `population`       | `population`                              | unchanged                                        |
+| `timezones`               | `timezones`        | `timezones`                               | unchanged                                        |
+| `independent`             | `classification`   | `classification.sovereign`                | closest match; see note below                    |
+| `unMember`                | `classification`   | `classification.un_member`                |                                                  |
+| `status`                  | `classification`   | `classification.iso_status`               | e.g. `"official"`                                |
+| `currencies`              | `currencies`       | `currencies[]`                            | `Record` → array of `{ code, name, symbol }`     |
+| `languages`               | `languages`        | `languages[].name`                        | `Record` → array of language objects             |
+| `demonyms`                | `demonyms`         | `demonyms`                                | shape unchanged (`{ [lang]: { f, m } }`)         |
+| `car.side`                | `cars`             | `cars.driving_side`                       | renamed                                          |
+| `car.signs`               | `cars`             | `cars.signs`                              |                                                  |
+| `tld`                     | `tlds`             | `tlds`                                    | renamed                                          |
+| `idd`                     | `calling_codes`    | `calling_codes`                           | `{ root, suffixes }` → `string[]`                |
+| `flag` (emoji)            | `flag`             | `flag.emoji`                              | `flag` is now an object                          |
+| `flags.png` / `flags.svg` | `flag`             | `flag.url_png`, `flag.url_svg`            |                                                  |
+| `flags.alt`               | `flag`             | `flag.description`                        |                                                  |
+| `maps.googleMaps`         | `links`            | `links.google_maps`                       |                                                  |
+| `maps.openStreetMaps`     | `links`            | `links.open_street_maps`                  |                                                  |
+| `gini`                    | `economy`          | `economy.gini_coefficient`                |                                                  |
+| `startOfWeek`             | `date`             | `date.start_of_week`                      |                                                  |
+| `postalCode`              | `postal_code`      | `postal_code.format`, `postal_code.regex` | renamed                                          |
 
 ### ❌ Removed in v5 (no equivalent)
 
@@ -121,19 +121,19 @@ Fields with no v2 counterpart: `memberships` (eu, nato, un, schengen, g7, g20, b
 Methods that return **lists** resolve to `{ countries, meta } | null` and accept `limit`/`offset`.
 Methods that return a **single** country resolve to `Country | null`.
 
-| Method | Returns |
-| --- | --- |
-| [`getCountries`](#getcountries) | list |
-| [`search`](#search) | list |
-| [`getCountriesByName`](#getcountriesbyname) | list |
-| [`getCountriesByRegion`](#getcountriesbyregion) | list |
-| [`getCountriesBySubregion`](#getcountriesbysubregion) | list |
-| [`getCountriesByLang`](#getcountriesbylang) | list |
-| [`getCountriesByCurrency`](#getcountriesbycurrency) | list |
-| [`getCountryByCode`](#getcountrybycode) | single |
-| [`getCountryByCapital`](#getcountrybycapital) | single |
-| [`getCountryByTranslation`](#getcountrybytranslation) | single |
-| [`getCountryByDemonym`](#getcountrybydemonym) | single |
+| Method                                                | Returns |
+| ----------------------------------------------------- | ------- |
+| [`getCountries`](#getcountries)                       | list    |
+| [`search`](#search)                                   | list    |
+| [`getCountriesByName`](#getcountriesbyname)           | list    |
+| [`getCountriesByRegion`](#getcountriesbyregion)       | list    |
+| [`getCountriesBySubregion`](#getcountriesbysubregion) | list    |
+| [`getCountriesByLang`](#getcountriesbylang)           | list    |
+| [`getCountriesByCurrency`](#getcountriesbycurrency)   | list    |
+| [`getCountryByCode`](#getcountrybycode)               | single  |
+| [`getCountryByCapital`](#getcountrybycapital)         | single  |
+| [`getCountryByTranslation`](#getcountrybytranslation) | single  |
+| [`getCountryByDemonym`](#getcountrybydemonym)         | single  |
 
 Additional information:
 
@@ -460,7 +460,7 @@ Every method accepts an optional second argument with any valid `fetch` options 
 // Next.js caching example
 const germany = await restCountries.getCountryByCode(
   { code: "DEU", fields: ["names", "capitals"] },
-  { next: { revalidate: 7 * 24 * 3600 }, cache: "force-cache" }
+  { next: { revalidate: 7 * 24 * 3600 }, cache: "force-cache" },
 );
 ```
 

--- a/README.MD
+++ b/README.MD
@@ -12,7 +12,7 @@ This package provides an easy and `TYPE-SAFE` way to interact with the [REST Cou
 > - **Pagination.** List methods now return `{ countries, meta }` and accept `limit`/`offset`.
 > - **New capabilities.** Free-text [`search()`](#search) and composable [`filters`](#filtering) (memberships, classification, landlocked, continent…).
 >
-> If you are on v2.x and want the old API surface, pin `@yusifaliyevpro/countries@2`.
+> Migrating from v2.x? See the [field map](#migrating-from-v2x-field-map) for the old→new property translations. If you're not ready to migrate, pin `@yusifaliyevpro/countries@2`.
 
 ## Installation
 
@@ -57,6 +57,65 @@ new RestCountries({
 
 **`Note:`** If you don't set the `fields` parameter, all data will be fetched.
 
+---
+
+## Migrating from v2.x (field map)
+
+v5 restructured the schema. Use this table to translate the `fields` you used to request and the properties you read off each country. Because `fields` selects at **top-level key granularity**, the "Request field" column is what you pass to `fields`; the "Read it as" column is the property path on the returned object.
+
+| v2 field | Request field (v5) | Read it as (v5) | Notes |
+| --- | --- | --- | --- |
+| `name` | `names` | `names.common`, `names.official` | |
+| `name.nativeName` | `names` | `names.native` | keyed by language code |
+| `altSpellings` | `names` | `names.alternates` | |
+| `translations` | `names` | `names.translations` | |
+| `cca2` | `codes` | `codes.alpha_2` | |
+| `cca3` | `codes` | `codes.alpha_3` | |
+| `ccn3` | `codes` | `codes.ccn3` | |
+| `cioc` | `codes` | `codes.cioc` | |
+| `fifa` | `codes` | `codes.fifa` | |
+| `capital` | `capitals` | `capitals[].name` | now objects: `{ name, coordinates, attributes }` |
+| `capitalInfo.latlng` | `capitals` | `capitals[].coordinates` | `{ lat, lng }` |
+| `latlng` | `coordinates` | `coordinates.lat`, `coordinates.lng` | tuple → object |
+| `region` | `region` | `region` | unchanged |
+| `subregion` | `subregion` | `subregion` | unchanged |
+| `continents` | `continents` | `continents` | unchanged |
+| `borders` | `borders` | `borders` | unchanged |
+| `landlocked` | `landlocked` | `landlocked` | unchanged |
+| `area` | `area` | `area.kilometers`, `area.miles` | number → object |
+| `population` | `population` | `population` | unchanged |
+| `timezones` | `timezones` | `timezones` | unchanged |
+| `independent` | `classification` | `classification.sovereign` | closest match; see note below |
+| `unMember` | `classification` | `classification.un_member` | |
+| `status` | `classification` | `classification.iso_status` | e.g. `"official"` |
+| `currencies` | `currencies` | `currencies[]` | `Record` → array of `{ code, name, symbol }` |
+| `languages` | `languages` | `languages[].name` | `Record` → array of language objects |
+| `demonyms` | `demonyms` | `demonyms` | shape unchanged (`{ [lang]: { f, m } }`) |
+| `car.side` | `cars` | `cars.driving_side` | renamed |
+| `car.signs` | `cars` | `cars.signs` | |
+| `tld` | `tlds` | `tlds` | renamed |
+| `idd` | `calling_codes` | `calling_codes` | `{ root, suffixes }` → `string[]` |
+| `flag` (emoji) | `flag` | `flag.emoji` | `flag` is now an object |
+| `flags.png` / `flags.svg` | `flag` | `flag.url_png`, `flag.url_svg` | |
+| `flags.alt` | `flag` | `flag.description` | |
+| `maps.googleMaps` | `links` | `links.google_maps` | |
+| `maps.openStreetMaps` | `links` | `links.open_street_maps` | |
+| `gini` | `economy` | `economy.gini_coefficient` | |
+| `startOfWeek` | `date` | `date.start_of_week` | |
+| `postalCode` | `postal_code` | `postal_code.format`, `postal_code.regex` | renamed |
+
+### ❌ Removed in v5 (no equivalent)
+
+- **`coatOfArms`** — coat-of-arms images are no longer provided by the API.
+
+### 🆕 New in v5
+
+Fields with no v2 counterpart: `memberships` (eu, nato, un, schengen, g7, g20, brics, opec, oecd, …), `classification.dependency` / `disputed` / `un_observer`, `codes.fips` / `gec`, `government_type`, `number_format`, `parent`, `uuid`, `date.academic_year_start` / `fiscal_year_start`, `flag.unicode` / `html_entity`, and `capitals[].attributes`.
+
+> **Note on `independent`:** v5 has no exact `independent` flag. `classification.sovereign` is the closest, but it isn't a 1:1 semantic match — if you relied on the old behaviour, also check `classification.dependency` and `classification.un_member`.
+
+---
+
 ## Methods
 
 Methods that return **lists** resolve to `{ countries, meta } | null` and accept `limit`/`offset`.
@@ -78,6 +137,7 @@ Methods that return a **single** country resolve to `Country | null`.
 
 Additional information:
 
+- [**`Migrating from v2.x (field map)`**](#migrating-from-v2x-field-map)
 - [**`Filtering (CountryFilters)`**](#filtering)
 - [**`Pagination`**](#pagination)
 - [**`Selecting fields (fields / omitFields)`**](#available-fields)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yusifaliyevpro/countries",
   "description": "TypeScript wrapper for Rest Countries API to fetch country data by codes, capitals, or all countries with full typings.",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,14 @@ const coordinates = z.strictObject({ lat: z.number(), lng: z.number() });
 const dayMonth = z.strictObject({ day: z.number(), month: z.number() });
 
 /**
+ * The v5 API serialises an **empty** map as `[]` (an empty array) instead of
+ * `{}`. So every map-valued field is modelled as `Record<…> | []` to stay
+ * faithful to the raw response — guard with `Array.isArray(value)` before use.
+ */
+const emptyMap = z.array(z.never());
+const mapOrEmpty = <V extends z.ZodMiniType>(value: V) => z.union([z.record(z.string(), value), emptyMap]);
+
+/**
  * Runtime schema for a country as returned by the REST Countries **v5** API,
  * and the single source of truth for the {@link Country} type (inferred below).
  *
@@ -27,8 +35,8 @@ export const countrySchema = z.strictObject({
     common: z.string(),
     official: z.string(),
     alternates: z.array(z.string()),
-    native: z.record(z.string(), localizedName),
-    translations: z.record(z.string(), localizedName),
+    native: mapOrEmpty(localizedName),
+    translations: mapOrEmpty(localizedName),
   }),
   codes: z.strictObject({
     alpha_2: z.string(),
@@ -79,7 +87,12 @@ export const countrySchema = z.strictObject({
   }),
   continents: z.array(z.string()),
   coordinates,
-  currencies: z.array(z.strictObject({ code: z.string(), name: z.string(), symbol: z.string() })),
+  // Usually an array of `{ code, name, symbol }`. A few entities (e.g. Somaliland)
+  // still return the old v4 record shape `{ [code]: { name, symbol } }`.
+  currencies: z.union([
+    z.array(z.strictObject({ code: z.string(), name: z.string(), symbol: z.string() })),
+    z.record(z.string(), z.strictObject({ name: z.string(), symbol: z.string() })),
+  ]),
   date: z.strictObject({
     academic_year_start: z.optional(dayMonth),
     fiscal_year_start: z.optional(
@@ -91,8 +104,8 @@ export const countrySchema = z.strictObject({
     ),
     start_of_week: z.string(),
   }),
-  demonyms: z.record(z.string(), z.strictObject({ f: z.string(), m: z.string() })),
-  economy: z.optional(z.strictObject({ gini_coefficient: z.record(z.string(), z.number()) })),
+  demonyms: mapOrEmpty(z.strictObject({ f: z.string(), m: z.string() })),
+  economy: z.optional(z.strictObject({ gini_coefficient: mapOrEmpty(z.number()) })),
   government_type: z.optional(z.string()),
   landlocked: z.boolean(),
   languages: z.array(

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,21 +1,46 @@
+import type { Country } from "@yusifaliyevpro/countries";
 import { countrySchema } from "@yusifaliyevpro/countries";
 import { rc } from "./client";
 
-// Well-populated sovereign countries that exercise every documented field.
-const samples = ["CAN", "DEU", "USA", "JPN", "BRA"] as const;
+/** Fetches every country (all properties) by paging through the API. */
+async function fetchAllCountries(): Promise<Country[]> {
+  const all: Country[] = [];
+  let offset = 0;
+  for (;;) {
+    const page = await rc.getCountries({ limit: 100, offset });
+    if (!page) throw new Error(`Failed to fetch countries at offset ${offset}`);
+    all.push(...page.countries);
+    if (!page.meta.more) break;
+    offset += page.meta.limit;
+  }
+  return all;
+}
 
 // `countrySchema` is the single source of truth for the `Country` type, so
-// validating a real v5 response against it confirms our types still match the
-// API. `strictObject` makes this fail if the API adds a field we don't model.
-test.each(samples)("the v5 response for %s conforms to the Country schema", async (code) => {
-  const country = await rc.getCountryByCode({ code });
-  expect(country).not.toBeNull();
+// validating EVERY country (with all properties) against it guarantees our
+// types match the live v5 API. `strictObject` also fails on any field the API
+// returns that we don't model — surfacing schema drift.
+test(
+  "every country in the API conforms to the Country schema",
+  async () => {
+    const countries = await fetchAllCountries();
+    expect(countries.length).toBeGreaterThan(200);
 
-  const result = countrySchema.safeParse(country);
-  if (!result.success) {
-    const details = result.error.issues
-      .map((issue: { path: PropertyKey[]; message: string }) => `  ${issue.path.join(".") || "(root)"}: ${issue.message}`)
-      .join("\n");
-    throw new Error(`Schema mismatches for ${code}:\n${details}`);
-  }
-});
+    const failures: string[] = [];
+    for (const country of countries) {
+      const result = countrySchema.safeParse(country);
+      if (!result.success) {
+        const name = country.names?.common ?? country.codes?.alpha_3 ?? "unknown";
+        const details = result.error.issues
+          .map((issue: { path: PropertyKey[]; message: string }) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+          .join("; ");
+        failures.push(`${name}: ${details}`);
+      }
+    }
+
+    if (failures.length) {
+      throw new Error(`${failures.length}/${countries.length} countries failed schema validation:\n${failures.join("\n")}`);
+    }
+  },
+  30_000,
+);

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -20,27 +20,23 @@ async function fetchAllCountries(): Promise<Country[]> {
 // validating EVERY country (with all properties) against it guarantees our
 // types match the live v5 API. `strictObject` also fails on any field the API
 // returns that we don't model — surfacing schema drift.
-test(
-  "every country in the API conforms to the Country schema",
-  async () => {
-    const countries = await fetchAllCountries();
-    expect(countries.length).toBeGreaterThan(200);
+test("every country in the API conforms to the Country schema", async () => {
+  const countries = await fetchAllCountries();
+  expect(countries.length).toBeGreaterThan(200);
 
-    const failures: string[] = [];
-    for (const country of countries) {
-      const result = countrySchema.safeParse(country);
-      if (!result.success) {
-        const name = country.names?.common ?? country.codes?.alpha_3 ?? "unknown";
-        const details = result.error.issues
-          .map((issue: { path: PropertyKey[]; message: string }) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
-          .join("; ");
-        failures.push(`${name}: ${details}`);
-      }
+  const failures: string[] = [];
+  for (const country of countries) {
+    const result = countrySchema.safeParse(country);
+    if (!result.success) {
+      const name = country.names?.common ?? country.codes?.alpha_3 ?? "unknown";
+      const details = result.error.issues
+        .map((issue: { path: PropertyKey[]; message: string }) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+        .join("; ");
+      failures.push(`${name}: ${details}`);
     }
+  }
 
-    if (failures.length) {
-      throw new Error(`${failures.length}/${countries.length} countries failed schema validation:\n${failures.join("\n")}`);
-    }
-  },
-  30_000,
-);
+  if (failures.length) {
+    throw new Error(`${failures.length}/${countries.length} countries failed schema validation:\n${failures.join("\n")}`);
+  }
+}, 30_000);


### PR DESCRIPTION
## Summary

Update the README to include migration details for version 5 and improve type validation in tests.

## Changes

- Added migration details for transitioning from v2.x to v5 in the README.
- Bumped the package version to 5.0.1.
- Enhanced type validation in tests to ensure compliance with the v5 API schema.

## Checklist

- [ ] Ran `pnpm check` locally
- [ ] No hardcoded secrets or API keys

