### PR TITLE
Breaking Change -- result type of functions changed for better type-safety

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,90 @@
+# Migrating to v5 (REST Countries v5)
+
+REST Countries shut down v1–v4 and now only serves **v5**, which **requires an API key** and **completely restructured the response schema**. This package's `v5` is a ground-up rewrite to match — the major version now tracks the API version.
+
+Because the v1–v4 endpoints are gone, **staying on v2.x of this package is no longer an option** — the old version can't reach a live API. Upgrading is required.
+
+## What changed at a glance
+
+- **API key is now required.** [Sign up here](https://restcountries.com/sign-up) to get one.
+- **New class-based API.** Instead of importing standalone functions, you create one `RestCountries` instance with your key and call methods on it.
+- **New data shape.** e.g. `name` → `names`, `cca2`/`cca3` → `codes.alpha_2`/`codes.alpha_3`, `capital: string[]` → `capitals: { name, coordinates, attributes }[]`.
+- **Pagination.** List methods now return `{ countries, meta }` and accept `limit`/`offset`.
+- **New capabilities.** Free-text `search()` and composable `filters` (memberships, classification, landlocked, continent…).
+
+See the [README](README.MD) for the full API reference.
+
+## Return shape: `{ success, … , error }` instead of `null`
+
+In v2.x, methods returned the data or `null`, so you had to null-check before using anything. v5 returns a **discriminated result** — narrow on `success` once and the data is fully typed (no `undefined`), and on failure you get the `Error`:
+
+```ts
+// v2.x
+const country = await getCountryByCode({ code: "CAN", fields: ["name"] });
+if (country === null) return; // had to remember this
+country.name.common;
+
+// v5
+const { success, country, error } = await restCountries.getCountryByCode({ code: "CAN", fields: ["names"] });
+if (!success) throw error; // `error` is an Error
+country.names.common; // `country` is narrowed — no null check
+```
+
+- **List endpoints** resolve to `{ success: true; countries; meta; error: undefined } | { success: false; countries: undefined; meta: undefined; error: Error }`.
+- **Single endpoints** resolve to `{ success: true; country; error: undefined } | { success: false; country: undefined; error: Error }` — **a not-found is `success: false`**, not an empty value.
+- Methods **never throw and never return `null`**. Accessing the data before checking `success` is a compile-time error.
+
+## Field map
+
+v5 restructured the schema. Use this table to translate the `fields` you used to request and the properties you read off each country. Because `fields` selects at **top-level key granularity**, the "Request field" column is what you pass to `fields`; the "Read it as" column is the property path on the returned object.
+
+| v2 field                  | Request field (v5) | Read it as (v5)                           | Notes                                            |
+| ------------------------- | ------------------ | ----------------------------------------- | ------------------------------------------------ |
+| `name`                    | `names`            | `names.common`, `names.official`          |                                                  |
+| `name.nativeName`         | `names`            | `names.native`                            | keyed by language code                           |
+| `altSpellings`            | `names`            | `names.alternates`                        |                                                  |
+| `translations`            | `names`            | `names.translations`                      |                                                  |
+| `cca2`                    | `codes`            | `codes.alpha_2`                           |                                                  |
+| `cca3`                    | `codes`            | `codes.alpha_3`                           |                                                  |
+| `ccn3`                    | `codes`            | `codes.ccn3`                              |                                                  |
+| `cioc`                    | `codes`            | `codes.cioc`                              |                                                  |
+| `fifa`                    | `codes`            | `codes.fifa`                              |                                                  |
+| `capital`                 | `capitals`         | `capitals[].name`                         | now objects: `{ name, coordinates, attributes }` |
+| `capitalInfo.latlng`      | `capitals`         | `capitals[].coordinates`                  | `{ lat, lng }`                                   |
+| `latlng`                  | `coordinates`      | `coordinates.lat`, `coordinates.lng`      | tuple → object                                   |
+| `region`                  | `region`           | `region`                                  | unchanged                                        |
+| `subregion`               | `subregion`        | `subregion`                               | unchanged                                        |
+| `continents`              | `continents`       | `continents`                              | unchanged                                        |
+| `borders`                 | `borders`          | `borders`                                 | unchanged                                        |
+| `landlocked`              | `landlocked`       | `landlocked`                              | unchanged                                        |
+| `area`                    | `area`             | `area.kilometers`, `area.miles`           | number → object                                  |
+| `population`              | `population`       | `population`                              | unchanged                                        |
+| `timezones`               | `timezones`        | `timezones`                               | unchanged                                        |
+| `independent`             | `classification`   | `classification.sovereign`                | closest match; see note below                    |
+| `unMember`                | `classification`   | `classification.un_member`                |                                                  |
+| `status`                  | `classification`   | `classification.iso_status`               | e.g. `"official"`                                |
+| `currencies`              | `currencies`       | `currencies[]`                            | `Record` → array of `{ code, name, symbol }`     |
+| `languages`               | `languages`        | `languages[].name`                        | `Record` → array of language objects             |
+| `demonyms`                | `demonyms`         | `demonyms`                                | shape unchanged (`{ [lang]: { f, m } }`)         |
+| `car.side`                | `cars`             | `cars.driving_side`                       | renamed                                          |
+| `car.signs`               | `cars`             | `cars.signs`                              |                                                  |
+| `tld`                     | `tlds`             | `tlds`                                    | renamed                                          |
+| `idd`                     | `calling_codes`    | `calling_codes`                           | `{ root, suffixes }` → `string[]`                |
+| `flag` (emoji)            | `flag`             | `flag.emoji`                              | `flag` is now an object                          |
+| `flags.png` / `flags.svg` | `flag`             | `flag.url_png`, `flag.url_svg`            |                                                  |
+| `flags.alt`               | `flag`             | `flag.description`                        |                                                  |
+| `maps.googleMaps`         | `links`            | `links.google_maps`                       |                                                  |
+| `maps.openStreetMaps`     | `links`            | `links.open_street_maps`                  |                                                  |
+| `gini`                    | `economy`          | `economy.gini_coefficient`                |                                                  |
+| `startOfWeek`             | `date`             | `date.start_of_week`                      |                                                  |
+| `postalCode`              | `postal_code`      | `postal_code.format`, `postal_code.regex` | renamed                                          |
+
+### ❌ Removed in v5 (no equivalent)
+
+- **`coatOfArms`** — coat-of-arms images are no longer provided by the API.
+
+### 🆕 New in v5
+
+Fields with no v2 counterpart: `memberships` (eu, nato, un, schengen, g7, g20, brics, opec, oecd, …), `classification.dependency` / `disputed` / `un_observer`, `codes.fips` / `gec`, `government_type`, `number_format`, `parent`, `uuid`, `date.academic_year_start` / `fiscal_year_start`, `flag.unicode` / `html_entity`, and `capitals[].attributes`.
+
+> **Note on `independent`:** v5 has no exact `independent` flag. `classification.sovereign` is the closest, but it isn't a 1:1 semantic match — if you relied on the old behaviour, also check `classification.dependency` and `classification.un_member`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -14,6 +14,28 @@ Because the v1–v4 endpoints are gone, **staying on v2.x of this package is no 
 
 See the [README](README.MD) for the full API reference.
 
+## Recommended setup: one shared client
+
+Instead of importing standalone functions everywhere (the v2.x style), create the client **once** in a dedicated file and reuse that instance across your app. This keeps the API key in a single place and avoids constructing a client per call:
+
+```ts
+// src/lib/countries.ts
+import { RestCountries } from "@yusifaliyevpro/countries";
+
+export const restCountries = new RestCountries({
+  apiKey: process.env.REST_COUNTRIES_API_KEY!,
+});
+```
+
+```ts
+// anywhere else
+import { restCountries } from "@/lib/countries";
+
+const { success, country, error } = await restCountries.getCountryByCode({ alpha_3: "CAN" });
+```
+
+> Keep the API key in an environment variable and never commit it. The constructor throws if the key is missing or empty.
+
 ## Return shape: `{ success, … , error }` instead of `null`
 
 In v2.x, methods returned the data or `null`, so you had to null-check before using anything. v5 returns a **discriminated result** — narrow on `success` once and the data is fully typed (no `undefined`), and on failure you get the `Error`:

--- a/README.MD
+++ b/README.MD
@@ -2,22 +2,16 @@
 
 This package provides an easy and `TYPE-SAFE` way to interact with the [REST Countries API](https://restcountries.com/), which offers detailed information about countries worldwide. You can fetch country data using various parameters like alpha-2/alpha-3/CIOC/CCN3 codes, capital cities, languages, regions, subregions, translations, demonyms and currencies. `Thanks to Alejandro Matos for this API.`
 
-> ## ⚠️ v5 — Breaking changes (REST Countries v5)
->
-> REST Countries shut down v1–v4 and now only serves **v5**, which **requires an API key** and **completely restructured the response schema**. This package's v5 is a ground-up rewrite to match (the major version now tracks the API version):
->
-> - **API key is now required.** [Sign up here](https://restcountries.com/sign-up) to get one.
-> - **New class-based API.** Instead of importing standalone functions, you create one `RestCountries` instance with your key and call methods on it.
-> - **New data shape.** e.g. `name` → `names`, `cca2`/`cca3` → `codes.alpha_2`/`codes.alpha_3`, `capital: string[]` → `capitals: { name, coordinates, attributes }[]`. See [Available Fields](#available-fields).
-> - **Pagination.** List methods now return `{ countries, meta }` and accept `limit`/`offset`.
-> - **New capabilities.** Free-text [`search()`](#search) and composable [`filters`](#filtering) (memberships, classification, landlocked, continent…).
->
-> Migrating from v2.x? See the [field map](#migrating-from-v2x-field-map) for the old→new property translations. If you're not ready to migrate, pin `@yusifaliyevpro/countries@2`.
+> ⚠️ **You are reading the v5 documentation.** v5 is a breaking, ground-up rewrite for REST Countries v5 (which shut down v1–v4). It now **requires an API key** and has a **new schema, class API, and pagination**. Coming from v2.x? Read the **[Migration guide](MIGRATION.md)**.
 
 ## Installation
 
 ```bash
 npm install @yusifaliyevpro/countries
+# or
+pnpm add @yusifaliyevpro/countries
+# or
+yarn add @yusifaliyevpro/countries
 ```
 
 ## Getting started
@@ -30,17 +24,21 @@ import { RestCountries } from "@yusifaliyevpro/countries";
 const restCountries = new RestCountries({ apiKey: process.env.REST_COUNTRIES_API_KEY! });
 
 // Fetch a single country
-const canada = await restCountries.getCountryByCode({
-  code: "CAN",
+const { success, country, error } = await restCountries.getCountryByCode({
+  alpha_3: "CAN",
   fields: ["names", "capitals", "flag"],
 });
+if (!success) throw error; // `error` is an Error here
+console.log(country.names.common); // `country` is fully typed — no null checks
 
 // Fetch a paginated list
-const { countries, meta } = await restCountries.getCountriesByRegion({
+const result = await restCountries.getCountriesByRegion({
   region: "Europe",
   fields: ["names", "population"],
   limit: 10,
 });
+if (!result.success) throw result.error;
+console.log(result.countries, result.meta);
 ```
 
 > **Keep your API key secret.** Load it from an environment variable (e.g. `.env`) — never commit it.
@@ -57,69 +55,30 @@ new RestCountries({
 
 **`Note:`** If you don't set the `fields` parameter, all data will be fetched.
 
----
-
-## Migrating from v2.x (field map)
-
-v5 restructured the schema. Use this table to translate the `fields` you used to request and the properties you read off each country. Because `fields` selects at **top-level key granularity**, the "Request field" column is what you pass to `fields`; the "Read it as" column is the property path on the returned object.
-
-| v2 field                  | Request field (v5) | Read it as (v5)                           | Notes                                            |
-| ------------------------- | ------------------ | ----------------------------------------- | ------------------------------------------------ |
-| `name`                    | `names`            | `names.common`, `names.official`          |                                                  |
-| `name.nativeName`         | `names`            | `names.native`                            | keyed by language code                           |
-| `altSpellings`            | `names`            | `names.alternates`                        |                                                  |
-| `translations`            | `names`            | `names.translations`                      |                                                  |
-| `cca2`                    | `codes`            | `codes.alpha_2`                           |                                                  |
-| `cca3`                    | `codes`            | `codes.alpha_3`                           |                                                  |
-| `ccn3`                    | `codes`            | `codes.ccn3`                              |                                                  |
-| `cioc`                    | `codes`            | `codes.cioc`                              |                                                  |
-| `fifa`                    | `codes`            | `codes.fifa`                              |                                                  |
-| `capital`                 | `capitals`         | `capitals[].name`                         | now objects: `{ name, coordinates, attributes }` |
-| `capitalInfo.latlng`      | `capitals`         | `capitals[].coordinates`                  | `{ lat, lng }`                                   |
-| `latlng`                  | `coordinates`      | `coordinates.lat`, `coordinates.lng`      | tuple → object                                   |
-| `region`                  | `region`           | `region`                                  | unchanged                                        |
-| `subregion`               | `subregion`        | `subregion`                               | unchanged                                        |
-| `continents`              | `continents`       | `continents`                              | unchanged                                        |
-| `borders`                 | `borders`          | `borders`                                 | unchanged                                        |
-| `landlocked`              | `landlocked`       | `landlocked`                              | unchanged                                        |
-| `area`                    | `area`             | `area.kilometers`, `area.miles`           | number → object                                  |
-| `population`              | `population`       | `population`                              | unchanged                                        |
-| `timezones`               | `timezones`        | `timezones`                               | unchanged                                        |
-| `independent`             | `classification`   | `classification.sovereign`                | closest match; see note below                    |
-| `unMember`                | `classification`   | `classification.un_member`                |                                                  |
-| `status`                  | `classification`   | `classification.iso_status`               | e.g. `"official"`                                |
-| `currencies`              | `currencies`       | `currencies[]`                            | `Record` → array of `{ code, name, symbol }`     |
-| `languages`               | `languages`        | `languages[].name`                        | `Record` → array of language objects             |
-| `demonyms`                | `demonyms`         | `demonyms`                                | shape unchanged (`{ [lang]: { f, m } }`)         |
-| `car.side`                | `cars`             | `cars.driving_side`                       | renamed                                          |
-| `car.signs`               | `cars`             | `cars.signs`                              |                                                  |
-| `tld`                     | `tlds`             | `tlds`                                    | renamed                                          |
-| `idd`                     | `calling_codes`    | `calling_codes`                           | `{ root, suffixes }` → `string[]`                |
-| `flag` (emoji)            | `flag`             | `flag.emoji`                              | `flag` is now an object                          |
-| `flags.png` / `flags.svg` | `flag`             | `flag.url_png`, `flag.url_svg`            |                                                  |
-| `flags.alt`               | `flag`             | `flag.description`                        |                                                  |
-| `maps.googleMaps`         | `links`            | `links.google_maps`                       |                                                  |
-| `maps.openStreetMaps`     | `links`            | `links.open_street_maps`                  |                                                  |
-| `gini`                    | `economy`          | `economy.gini_coefficient`                |                                                  |
-| `startOfWeek`             | `date`             | `date.start_of_week`                      |                                                  |
-| `postalCode`              | `postal_code`      | `postal_code.format`, `postal_code.regex` | renamed                                          |
-
-### ❌ Removed in v5 (no equivalent)
-
-- **`coatOfArms`** — coat-of-arms images are no longer provided by the API.
-
-### 🆕 New in v5
-
-Fields with no v2 counterpart: `memberships` (eu, nato, un, schengen, g7, g20, brics, opec, oecd, …), `classification.dependency` / `disputed` / `un_observer`, `codes.fips` / `gec`, `government_type`, `number_format`, `parent`, `uuid`, `date.academic_year_start` / `fiscal_year_start`, `flag.unicode` / `html_entity`, and `capitals[].attributes`.
-
-> **Note on `independent`:** v5 has no exact `independent` flag. `classification.sovereign` is the closest, but it isn't a 1:1 semantic match — if you relied on the old behaviour, also check `classification.dependency` and `classification.un_member`.
-
----
+> 📦 **Migrating from v2.x?** The full field-by-field map (old → new) lives in **[MIGRATION.md](MIGRATION.md)**.
 
 ## Methods
 
-Methods that return **lists** resolve to `{ countries, meta } | null` and accept `limit`/`offset`.
-Methods that return a **single** country resolve to `Country | null`.
+Every method resolves to a **discriminated result** — never `null`. Destructure all the keys and narrow on `success`; TypeScript then drops `undefined` from the data, so you don't write any null checks:
+
+```typescript
+// List endpoints → { success, countries, meta, error }
+const { success, countries, meta, error } = await restCountries.getCountriesByLang({
+  lang: "Spanish",
+  fields: ["names", "languages"],
+  limit: 100,
+});
+if (!success) throw error; // narrow once…
+countries; // …now CountryPicker<T>[]  (not undefined)
+meta; // ResponseMeta
+
+// Single endpoints → { success, country, error }
+const res = await restCountries.getCountryByCode({ alpha_3: "CAN" });
+if (!res.success) throw res.error;
+res.country; // CountryPicker<T>
+```
+
+On failure (network error, auth failure, or not-found) you get `{ success: false, error: Error, … }` — the method never throws and never returns `null`. List endpoints accept `limit`/`offset` ([Pagination](#pagination)).
 
 | Method                                                | Returns |
 | ----------------------------------------------------- | ------- |
@@ -137,7 +96,7 @@ Methods that return a **single** country resolve to `Country | null`.
 
 Additional information:
 
-- [**`Migrating from v2.x (field map)`**](#migrating-from-v2x-field-map)
+- [**`Migrating from v2.x`**](MIGRATION.md)
 - [**`Filtering (CountryFilters)`**](#filtering)
 - [**`Pagination`**](#pagination)
 - [**`Selecting fields (fields / omitFields)`**](#available-fields)
@@ -325,22 +284,25 @@ const { countries } = await restCountries.getCountriesByCurrency({
 
 ### `getCountryByCode`
 
-Fetches a single country by its code. Detects the code type (alpha-2, alpha-3, CCN3) and falls back to CIOC for three-letter codes.
+Fetches a single country by **one** code, identified by its kind. Pass **exactly one** of `alpha_2`, `alpha_3`, `ccn3`, or `cioc` — passing none or more than one is a compile-time error.
 
 #### Parameters:
 
-- `code`: An alpha-3, alpha-2, CCN3 or CIOC code (case-insensitive) (autocomplete).
-- `fields` (optional): Array of fields to retrieve.
+- one of `alpha_2` / `alpha_3` / `ccn3` / `cioc`: the code value (autocomplete per type).
+- `fields` / `omitFields` (optional): field selection.
 
 #### Example:
 
 ```typescript
-const azerbaijan = await restCountries.getCountryByCode({ code: "AZE" });
+const { success, country: azerbaijan } = await restCountries.getCountryByCode({ alpha_3: "AZE" });
 
-const switzerland = await restCountries.getCountryByCode({
-  code: "SUI", // CIOC code — resolved via fallback
+const { country: switzerland } = await restCountries.getCountryByCode({
+  cioc: "SUI", // IOC code (differs from alpha-3 "CHE")
   fields: ["names", "codes", "population"],
 });
+
+// @ts-expect-error — can't pass two codes
+restCountries.getCountryByCode({ alpha_2: "US", alpha_3: "USA" });
 ```
 
 ---
@@ -357,7 +319,7 @@ Fetches a single country by its capital city.
 #### Example:
 
 ```typescript
-const germany = await restCountries.getCountryByCapital({
+const { country: germany } = await restCountries.getCountryByCapital({
   capital: "Berlin",
   fields: ["names", "flag", "currencies"],
 });
@@ -377,7 +339,7 @@ Fetches a single country by a translated name.
 #### Example:
 
 ```typescript
-const germany = await restCountries.getCountryByTranslation({
+const { country: germany } = await restCountries.getCountryByTranslation({
   translation: "Deutschland",
   fields: ["cars", "capitals", "codes"],
 });
@@ -397,7 +359,7 @@ Fetches a single country by its demonym.
 #### Example:
 
 ```typescript
-const peru = await restCountries.getCountryByDemonym({
+const { country: peru } = await restCountries.getCountryByDemonym({
   demonym: "Peruvian",
   fields: ["cars", "capitals", "codes"],
 });
@@ -432,20 +394,21 @@ All filter keys are optional and fully typed. `classification` and `memberships`
 REST Countries v5 paginates results (default 25 per page, max 100). List methods expose `limit` and `offset` and return a `meta` object describing the current page:
 
 ```typescript
-const { countries, meta } = await restCountries.getCountriesByRegion({
+const result = await restCountries.getCountriesByRegion({
   region: "Africa",
   fields: ["names"],
   limit: 100,
   offset: 0,
 });
+if (!result.success) throw result.error;
 
-// meta: { total, count, limit, offset, more, request_id, duration }
-if (meta.more) {
+// result.meta: { total, count, limit, offset, more, request_id, duration }
+if (result.meta.more) {
   const next = await restCountries.getCountriesByRegion({
     region: "Africa",
     fields: ["names"],
     limit: 100,
-    offset: meta.offset + meta.limit,
+    offset: result.meta.offset + result.meta.limit,
   });
 }
 ```
@@ -458,8 +421,8 @@ Every method accepts an optional second argument with any valid `fetch` options 
 
 ```typescript
 // Next.js caching example
-const germany = await restCountries.getCountryByCode(
-  { code: "DEU", fields: ["names", "capitals"] },
+const { country: germany } = await restCountries.getCountryByCode(
+  { alpha_3: "DEU", fields: ["names", "capitals"] },
   { next: { revalidate: 7 * 24 * 3600 }, cache: "force-cache" },
 );
 ```
@@ -508,8 +471,8 @@ const { countries } = await restCountries.getCountries({ omitFields: ["leaders"]
 > **Note:** `omitFields` is applied at runtime only; it does not narrow the return type (you still get the full `Country` type). Use `fields` when you want the type narrowed.
 
 ```typescript
-const country = await restCountries.getCountryByCode({
-  code: "TUR",
+const { country } = await restCountries.getCountryByCode({
+  alpha_3: "TUR",
   fields: ["names", "capitals", "population"],
 });
 ```
@@ -529,7 +492,8 @@ import type { Country, Region, Cca2Code } from "@yusifaliyevpro/countries/types"
 **`Note:` If a long time has passed since the last update, the type data may be outdated.**
 
 - **`Country`**: Comprehensive type for a v5 country object.
-- **`CountryList`**: `{ countries: CountryPicker<T>[]; meta: ResponseMeta }` returned by list methods.
+- **`CountryListResult`**: Discriminated result of list methods — `{ success: true; countries; meta; error: undefined } | { success: false; countries: undefined; meta: undefined; error: Error }`.
+- **`CountryResult`**: Discriminated result of single-country methods (`country` instead of `countries`/`meta`).
 - **`ResponseMeta`**: Pagination metadata (`total`, `count`, `limit`, `offset`, `more`, `request_id`, `duration`).
 - **`CountryPicker`**: Picks the requested top-level fields from `Country`.
 - **`CountryFilters`**: Typed, composable filters for `getCountries` / `search`.
@@ -551,9 +515,11 @@ The `Country` type is **inferred from a [Zod Mini](https://zod.dev/packages/mini
 ```typescript
 import { countrySchema } from "@yusifaliyevpro/countries";
 
-const country = await restCountries.getCountryByCode({ code: "CAN" });
-const result = countrySchema.safeParse(country);
-if (!result.success) console.error(result.error.issues);
+const res = await restCountries.getCountryByCode({ alpha_3: "CAN" });
+if (res.success) {
+  const parsed = countrySchema.safeParse(res.country);
+  if (!parsed.success) console.error(parsed.error.issues);
+}
 ```
 
 Zod Mini is used to keep the footprint small, and the schema is only pulled into your bundle if you actually import `countrySchema` (the package is marked side-effect-free).
@@ -569,7 +535,7 @@ import { defineFields } from "@yusifaliyevpro/countries";
 
 const countryFields = defineFields(["names", "capitals", "population", "region", "codes", "flag"]);
 
-const country = await restCountries.getCountryByCode({ code: "DEU", fields: countryFields });
+const { country } = await restCountries.getCountryByCode({ alpha_3: "DEU", fields: countryFields });
 ```
 
 ---
@@ -586,7 +552,8 @@ export const countryFields = defineFields(["names", "capitals", "population", "r
 
 // src/app/page.tsx
 export default async function CountryPage() {
-  const country = await restCountries.getCountryByCode({ code: "AZ", fields: countryFields });
+  const { success, country, error } = await restCountries.getCountryByCode({ alpha_2: "AZ", fields: countryFields });
+  if (!success) throw error;
   return (
     <main>
       <CountryCard country={country} />
@@ -611,23 +578,27 @@ export function CountryCard({ country }: { country: CountryPicker<typeof country
 
 ## Error Handling
 
-Errors are handled gracefully and logged to the console. On a not-found, network, or authentication error the method resolves to `null` (single) or an empty page / `null` (lists).
+Methods **never throw and never return `null`**. Every failure — not-found, network error, or invalid API key — comes back as `{ success: false, error: Error }`. Narrow on `success` to handle it:
 
 ```typescript
-const data = await restCountries.getCountryByCode({
-  code: "XXX",
-  fields: ["names"],
-}); // null, with an error logged by the library
-
-const usa = await restCountries.getCountryByCode({
-  code: "USA",
-  fields: ["names", "population"],
-});
-
-// TypeScript Error — 'capitals' was not requested in fields
-console.log(usa.capitals);
-                ^^^^^^^^
+const res = await restCountries.getCountryByCode({ alpha_3: "XXX", fields: ["names"] });
+if (!res.success) {
+  console.error(res.error.message); // e.g. "Couldn't find any country…"
+} else {
+  console.log(res.country.names.common);
+}
 ```
+
+Because the result is a discriminated union, accessing the data before checking `success` is a **compile-time error** — you can't forget to handle failure:
+
+```typescript
+const res = await restCountries.getCountryByCode({ alpha_3: "USA", fields: ["names"] });
+
+res.country.names.common;
+//  ^^^^^^^ TS error: 'country' is possibly 'undefined' until you check `res.success`
+```
+
+Field selection is enforced the same way — accessing a field you didn't request (`fields: ["names"]` then `.capitals`) is a type error.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yusifaliyevpro/countries",
   "description": "TypeScript wrapper for Rest Countries API to fetch country data by codes, capitals, or all countries with full typings.",
-  "version": "5.0.3",
+  "version": "5.1.0",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,20 @@
 import { API_BASE_URL } from "./constants";
-import type { Capital, Country, CountryList, CountryPicker, Currency, Lang, Region, ResponseMeta, Subregion } from "./types";
-import type { Code } from "./types/common";
+import { countryFailure, errorFromResponse, countryListFailure, NOT_FOUND_MESSAGE, ok, type RawEnvelope } from "./helpers";
+import type {
+  Capital,
+  Cca2Code,
+  Cca3Code,
+  Ccn3Code,
+  CiocCode,
+  Country,
+  CountryListResult,
+  CountryPicker,
+  CountryResult,
+  Currency,
+  Lang,
+  Region,
+  Subregion,
+} from "./types";
 
 /**
  * Configuration for a {@link RestCountries} client instance.
@@ -40,6 +54,22 @@ export type CountryFilters = {
   memberships?: BooleanFlags<Country["memberships"]>;
 };
 
+/**
+ * Identifies a country by **exactly one** code type. Providing zero or more than
+ * one key is a type error.
+ *
+ * @example
+ * { alpha_3: "USA" }   // ISO 3166-1 alpha-3
+ * { alpha_2: "US" }    // ISO 3166-1 alpha-2
+ * { ccn3: "840" }      // ISO 3166-1 numeric
+ * { cioc: "USA" }      // IOC code
+ */
+export type CountryCodeQuery =
+  | { alpha_2: Cca2Code; alpha_3?: never; ccn3?: never; cioc?: never }
+  | { alpha_3: Cca3Code; alpha_2?: never; ccn3?: never; cioc?: never }
+  | { ccn3: Ccn3Code; alpha_2?: never; alpha_3?: never; cioc?: never }
+  | { cioc: CiocCode; alpha_2?: never; alpha_3?: never; ccn3?: never };
+
 /** Field selection shared by every endpoint. */
 type Selection<T extends Fields> = {
   /** Top-level fields to include (maps to `response_fields`). */
@@ -58,11 +88,6 @@ type Pagination = {
 
 type RequestParams<T extends Fields> = { q?: string; filters?: CountryFilters } & Selection<T> & Pagination;
 
-type RawEnvelope<C> = {
-  data?: { objects?: (C & { _match?: unknown; _meta?: unknown })[]; meta?: ResponseMeta };
-  errors?: { message: string }[];
-};
-
 function appendFilters(search: URLSearchParams, filters: CountryFilters): void {
   const { region, subregion, continent, landlocked, classification, memberships } = filters;
   if (region !== undefined) search.set("region", region);
@@ -77,20 +102,6 @@ function appendFilters(search: URLSearchParams, filters: CountryFilters): void {
   }
 }
 
-function handleNotFound(): void {
-  console.error(
-    "Couldn't find any country that matches your query. If you think this is a bug, please report it via GitHub issues: https://github.com/yusifaliyevpro/countries",
-  );
-}
-
-function handleNetworkError(error: unknown): void {
-  console.warn("A network or REST Countries API side error happened while fetching data. Try again later.");
-  console.warn(
-    "If this error persists, please verify the status of the REST Countries API. If the issue continues, feel free to report it on GitHub: https://github.com/yusifaliyevpro/countries",
-  );
-  console.error(error);
-}
-
 /**
  * A typed client for the REST Countries **v5** API.
  *
@@ -100,8 +111,9 @@ function handleNetworkError(error: unknown): void {
  * @example
  * const restCountries = new RestCountries({ apiKey: process.env.REST_COUNTRIES_API_KEY! });
  *
- * const canada = await restCountries.getCountryByCode({ code: "CAN", fields: ["names", "capitals"] });
- * const { countries } = await restCountries.getCountries({ filters: { region: "Europe", memberships: { eu: true } } });
+ * const { success, country, error } = await restCountries.getCountryByCode({ alpha_3: "CAN", fields: ["names"] });
+ * if (!success) throw error;
+ * console.log(country.names.common);
  */
 export class RestCountries {
   readonly #apiKey: string;
@@ -116,14 +128,15 @@ export class RestCountries {
   }
 
   /**
-   * Performs a request against the v5 API and unwraps the `data` envelope.
-   * Returns `null` on a not-found / network / auth error (after logging).
+   * Performs a request against the v5 API and unwraps the `data` envelope into
+   * a {@link CountryListResult}. Never throws — failures are returned as
+   * `{ success: false, error }`.
    */
   async #request<T extends Fields>(
     path: string,
     params: RequestParams<T>,
     fetchOptions?: RequestInit,
-  ): Promise<{ countries: CountryPicker<T>[]; meta: ResponseMeta } | null> {
+  ): Promise<CountryListResult<T>> {
     try {
       const url = new URL(this.#baseURL.replace(/\/$/, "") + path);
       if (params.q !== undefined) url.searchParams.set("q", params.q);
@@ -140,15 +153,18 @@ export class RestCountries {
         headers: { Authorization: `Bearer ${this.#apiKey}`, ...fetchOptions?.headers },
       });
 
-      if (response.status === 401 || response.status === 403) {
-        console.error("REST Countries: authentication failed. Check that your `apiKey` is valid and active.");
-        return null;
+      // Read as text first so a non-JSON error body (HTML 500, plain-text rate
+      // limit, …) doesn't throw and lose the status — we surface it instead.
+      const rawText = await response.text();
+      let body: RawEnvelope<CountryPicker<T>> | undefined;
+      try {
+        body = rawText ? (JSON.parse(rawText) as RawEnvelope<CountryPicker<T>>) : undefined;
+      } catch {
+        body = undefined;
       }
 
-      const body = (await response.json()) as RawEnvelope<CountryPicker<T>>;
-      if (!response.ok || !body.data?.objects) {
-        handleNotFound();
-        return null;
+      if (!response.ok || !body?.data?.objects) {
+        return countryListFailure(errorFromResponse(response, body, rawText));
       }
 
       // Strip the per-result `_match` / `_meta` search annotations so callers
@@ -163,21 +179,19 @@ export class RestCountries {
         request_id: "",
         duration: 0,
       };
-      return { countries, meta };
+      return ok({ countries, meta });
     } catch (error) {
-      handleNetworkError(error);
-      return null;
+      return countryListFailure(error instanceof Error ? error : new Error(String(error)));
     }
   }
 
-  /** Like {@link RestCountries.#request} but returns only the first matching country. */
-  async #first<T extends Fields>(
-    path: string,
-    params: RequestParams<T>,
-    fetchOptions?: RequestInit,
-  ): Promise<CountryPicker<T> | null> {
+  /** Like {@link RestCountries.#request} but resolves to a single-country {@link CountryResult}. */
+  async #first<T extends Fields>(path: string, params: RequestParams<T>, fetchOptions?: RequestInit): Promise<CountryResult<T>> {
     const result = await this.#request<T>(path, { ...params, limit: 1 }, fetchOptions);
-    return result?.countries[0] ?? null;
+    if (!result.success) return countryFailure(result.error);
+    const country = result.countries[0];
+    if (!country) return countryFailure(new Error(NOT_FOUND_MESSAGE));
+    return ok({ country });
   }
 
   /**
@@ -195,7 +209,7 @@ export class RestCountries {
   async getCountries<T extends Fields>(
     { q, filters, fields, omitFields, limit, offset }: { q?: string; filters?: CountryFilters } & Selection<T> & Pagination = {},
     fetchOptions?: RequestInit,
-  ): Promise<CountryList<T> | null> {
+  ): Promise<CountryListResult<T>> {
     return this.#request<T>("", { q, filters, fields, omitFields, limit, offset }, fetchOptions);
   }
 
@@ -210,32 +224,40 @@ export class RestCountries {
     q: string,
     { filters, fields, omitFields, limit, offset }: { filters?: CountryFilters } & Selection<T> & Pagination = {},
     fetchOptions?: RequestInit,
-  ): Promise<CountryList<T> | null> {
+  ): Promise<CountryListResult<T>> {
     return this.#request<T>("", { q, filters, fields, omitFields, limit, offset }, fetchOptions);
   }
 
   /**
-   * Fetches a single country by its code (alpha-2, alpha-3, CCN3 or CIOC).
-   * Tries the exact-match route for the detected code type, falling back to
-   * CIOC for three-letter codes.
+   * Fetches a single country by **one** code, identified by its kind. Pass
+   * exactly one of `alpha_2`, `alpha_3`, `ccn3`, or `cioc` (see {@link CountryCodeQuery}).
    *
    * @example
-   * const usa = await restCountries.getCountryByCode({ code: "USA", fields: ["names", "flag"] });
+   * const { success, country, error } = await restCountries.getCountryByCode({ alpha_3: "USA", fields: ["names", "flag"] });
+   * if (success) console.log(country.names.common);
+   *
+   * @example
+   * await restCountries.getCountryByCode({ cioc: "SUI" }); // Switzerland by IOC code
    */
   async getCountryByCode<T extends Fields>(
-    { code, fields, omitFields }: { code: Code } & Selection<T>,
+    { alpha_2, alpha_3, ccn3, cioc, fields, omitFields }: CountryCodeQuery & Selection<T>,
     fetchOptions?: RequestInit,
-  ): Promise<CountryPicker<T> | null> {
-    const value = String(code).trim();
-    let property: string;
-    if (/^\d+$/.test(value)) property = "codes.ccn3";
-    else if (value.length === 2) property = "codes.alpha_2";
-    else property = "codes.alpha_3";
+  ): Promise<CountryResult<T>> {
+    const codes = [
+      ["codes.alpha_2", alpha_2],
+      ["codes.alpha_3", alpha_3],
+      ["codes.ccn3", ccn3],
+      ["codes.cioc", cioc],
+    ] as const;
+    const match = codes.find(([, value]) => value !== undefined);
 
-    const country = await this.#first<T>(`/${property}/${encodeURIComponent(value)}`, { fields, omitFields }, fetchOptions);
-    if (country || property !== "codes.alpha_3") return country;
-    // Three-letter code that isn't an alpha-3 — it may be a CIOC code (e.g. "SUI").
-    return this.#first<T>(`/codes.cioc/${encodeURIComponent(value)}`, { fields, omitFields }, fetchOptions);
+    if (!match) {
+      return countryFailure(
+        new Error("RestCountries: provide exactly one country code — `alpha_2`, `alpha_3`, `ccn3`, or `cioc`."),
+      );
+    }
+    const [property, value] = match;
+    return this.#first<T>(`/${property}/${encodeURIComponent(String(value))}`, { fields, omitFields }, fetchOptions);
   }
 
   /**
@@ -249,7 +271,7 @@ export class RestCountries {
   async getCountriesByName<T extends Fields>(
     { name, fullText, fields, omitFields, limit, offset }: { name: string; fullText?: boolean } & Selection<T> & Pagination,
     fetchOptions?: RequestInit,
-  ): Promise<CountryList<T> | null> {
+  ): Promise<CountryListResult<T>> {
     const path = fullText ? `/names.common/${encodeURIComponent(name)}` : "/name";
     return this.#request<T>(path, { q: fullText ? undefined : name, fields, omitFields, limit, offset }, fetchOptions);
   }
@@ -263,7 +285,7 @@ export class RestCountries {
   async getCountriesByRegion<T extends Fields>(
     { region, fields, omitFields, limit, offset }: { region: Region } & Selection<T> & Pagination,
     fetchOptions?: RequestInit,
-  ): Promise<CountryList<T> | null> {
+  ): Promise<CountryListResult<T>> {
     return this.#request<T>(`/region/${encodeURIComponent(region)}`, { fields, omitFields, limit, offset }, fetchOptions);
   }
 
@@ -276,7 +298,7 @@ export class RestCountries {
   async getCountriesBySubregion<T extends Fields>(
     { subregion, fields, omitFields, limit, offset }: { subregion: Subregion } & Selection<T> & Pagination,
     fetchOptions?: RequestInit,
-  ): Promise<CountryList<T> | null> {
+  ): Promise<CountryListResult<T>> {
     return this.#request<T>(`/subregion/${encodeURIComponent(subregion)}`, { fields, omitFields, limit, offset }, fetchOptions);
   }
 
@@ -289,7 +311,7 @@ export class RestCountries {
   async getCountriesByLang<T extends Fields>(
     { lang, fields, omitFields, limit, offset }: { lang: Lang } & Selection<T> & Pagination,
     fetchOptions?: RequestInit,
-  ): Promise<CountryList<T> | null> {
+  ): Promise<CountryListResult<T>> {
     return this.#request<T>("/languages", { q: lang as string, fields, omitFields, limit, offset }, fetchOptions);
   }
 
@@ -302,7 +324,7 @@ export class RestCountries {
   async getCountriesByCurrency<T extends Fields>(
     { currency, fields, omitFields, limit, offset }: { currency: Currency } & Selection<T> & Pagination,
     fetchOptions?: RequestInit,
-  ): Promise<CountryList<T> | null> {
+  ): Promise<CountryListResult<T>> {
     return this.#request<T>("/currencies", { q: currency as string, fields, omitFields, limit, offset }, fetchOptions);
   }
 
@@ -310,12 +332,12 @@ export class RestCountries {
    * Fetches a single country by its capital city.
    *
    * @example
-   * const japan = await restCountries.getCountryByCapital({ capital: "Tokyo", fields: ["names"] });
+   * const { success, country } = await restCountries.getCountryByCapital({ capital: "Tokyo", fields: ["names"] });
    */
   async getCountryByCapital<T extends Fields>(
     { capital, fields, omitFields }: { capital: Capital } & Selection<T>,
     fetchOptions?: RequestInit,
-  ): Promise<CountryPicker<T> | null> {
+  ): Promise<CountryResult<T>> {
     return this.#first<T>("/capitals", { q: capital as string, fields, omitFields }, fetchOptions);
   }
 
@@ -323,12 +345,12 @@ export class RestCountries {
    * Fetches a single country by demonym (e.g. "Canadian", "French").
    *
    * @example
-   * const canada = await restCountries.getCountryByDemonym({ demonym: "Canadian", fields: ["names"] });
+   * const { success, country } = await restCountries.getCountryByDemonym({ demonym: "Canadian", fields: ["names"] });
    */
   async getCountryByDemonym<T extends Fields>(
     { demonym, fields, omitFields }: { demonym: string } & Selection<T>,
     fetchOptions?: RequestInit,
-  ): Promise<CountryPicker<T> | null> {
+  ): Promise<CountryResult<T>> {
     return this.#first<T>("/demonyms", { q: demonym, fields, omitFields }, fetchOptions);
   }
 
@@ -336,12 +358,12 @@ export class RestCountries {
    * Fetches a single country by a translated name (e.g. "Deutschland", "Alemania").
    *
    * @example
-   * const germany = await restCountries.getCountryByTranslation({ translation: "Deutschland", fields: ["names"] });
+   * const { success, country } = await restCountries.getCountryByTranslation({ translation: "Deutschland", fields: ["names"] });
    */
   async getCountryByTranslation<T extends Fields>(
     { translation, fields, omitFields }: { translation: string } & Selection<T>,
     fetchOptions?: RequestInit,
-  ): Promise<CountryPicker<T> | null> {
+  ): Promise<CountryResult<T>> {
     return this.#first<T>("/names.translations", { q: translation, fields, omitFields }, fetchOptions);
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -121,8 +121,11 @@ export class RestCountries {
   readonly #fetch: typeof fetch;
 
   constructor(config: RestCountriesConfig) {
-    if (!config?.apiKey) throw new Error("RestCountries: `apiKey` is required. Get one at https://restcountries.com/sign-up");
-    this.#apiKey = config.apiKey;
+    const apiKey = config?.apiKey?.trim();
+    if (!apiKey) {
+      throw new Error("RestCountries: `apiKey` is required and cannot be empty. Get one at https://restcountries.com/sign-up");
+    }
+    this.#apiKey = apiKey;
     this.#baseURL = config.baseURL ?? API_BASE_URL;
     this.#fetch = config.fetch ?? globalThis.fetch;
   }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,72 @@
+import type { ResponseMeta } from "./types";
+
+export const NOT_FOUND_MESSAGE =
+  "Couldn't find any country that matches your query. If you think this is a bug, please report it via GitHub issues: https://github.com/yusifaliyevpro/countries";
+
+/** The raw v5 response envelope (`{ data: { objects, meta } }` or `{ errors }`). */
+export type RawEnvelope<C> = {
+  data?: { objects?: (C & { _match?: unknown; _meta?: unknown })[]; meta?: ResponseMeta };
+  errors?: { message: string }[];
+};
+
+/**
+ * Structured detail attached to a failed request's `error.cause` for
+ * programmatic handling (e.g. `(error.cause as ErrorCause).status === 429`).
+ */
+export type ErrorCause = { status: number; statusText: string; body: unknown; headers: Record<string, string> };
+
+/** Wraps any object as a successful result: `{ ...value, success: true, error: undefined }`. */
+export function ok<T extends object>(value: T): T & { success: true; error: undefined } {
+  return { ...value, success: true, error: undefined };
+}
+
+/** The failure branch of a `CountryListResult`. */
+export function countryListFailure(error: Error): { success: false; countries: undefined; meta: undefined; error: Error } {
+  return { success: false, countries: undefined, meta: undefined, error };
+}
+
+/** The failure branch of a `CountryResult`. */
+export function countryFailure(error: Error): { success: false; country: undefined; error: Error } {
+  return { success: false, country: undefined, error };
+}
+
+/**
+ * Builds an `Error` that carries everything the server reported: a status-aware
+ * summary, **all** of the API's error messages, and the raw payload + status on
+ * `error.cause` (typed as {@link ErrorCause}) for programmatic handling.
+ */
+export function errorFromResponse(response: Response, body: RawEnvelope<unknown> | undefined, rawText: string): Error {
+  // Every message the server sent (v5 returns `{ errors: [{ message }] }`).
+  const serverMessages = (body?.errors ?? []).map((e) => e?.message).filter((m): m is string => Boolean(m));
+  // Fall back to the raw (possibly non-JSON, e.g. HTML/plain-text) body.
+  const detail = serverMessages.length ? serverMessages.join("; ") : rawText.trim().slice(0, 1000);
+
+  let summary: string;
+  switch (response.status) {
+    case 401:
+    case 403:
+      summary =
+        "authentication failed — check that your `apiKey` is valid, active, and (for browsers) that the request origin is allowed";
+      break;
+    case 429: {
+      const retryAfter = response.headers.get("retry-after");
+      summary = `rate limit exceeded${retryAfter ? ` — retry after ${retryAfter}s` : " — slow down or upgrade your plan"}`;
+      break;
+    }
+    case 404:
+      summary = serverMessages.length ? "not found" : NOT_FOUND_MESSAGE;
+      break;
+    default:
+      summary = response.ok ? "unexpected response shape" : "request failed";
+  }
+
+  const status = `HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ""}`;
+  const message = `REST Countries: ${summary} (${status})${detail && detail !== summary ? ` — ${detail}` : ""}`;
+  const cause: ErrorCause = {
+    status: response.status,
+    statusText: response.statusText,
+    body: body ?? rawText,
+    headers: Object.fromEntries(response.headers),
+  };
+  return new Error(message, { cause });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
 import type { Country } from "./types";
 
 export { RestCountries } from "./client";
-export type { CountryFilters, RestCountriesConfig } from "./client";
+export type { CountryCodeQuery, CountryFilters, RestCountriesConfig } from "./client";
+export { ok } from "./helpers";
+export type { ErrorCause } from "./helpers";
 export { countrySchema } from "./types";
-export type { Country, CountryList, CountryPicker, ResponseMeta } from "./types";
+export type { Country, CountryListResult, CountryPicker, CountryResult, ResponseMeta } from "./types";
 
 /**
  * Type-safe helper for declaring a `fields` array outside of a call site while

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -197,13 +197,32 @@ export type ResponseMeta = {
 };
 
 /**
- * The shape returned by list endpoints: the selected countries plus the
- * pagination {@link ResponseMeta}.
+ * Discriminated result returned by **list** endpoints. Destructure all four
+ * keys and narrow on `success` — TypeScript drops the `undefined`s from
+ * `countries`/`meta` once you've checked it:
+ *
+ * @example
+ * const { success, countries, meta, error } = await restCountries.getCountriesByRegion({ region: "Europe" });
+ * if (!success) throw error; // `error` is Error here
+ * countries; // CountryPicker<T>[]  (no undefined)
+ * meta;      // ResponseMeta
  */
-export type CountryList<T extends readonly (keyof Country)[]> = {
-  countries: CountryPicker<T>[];
-  meta: ResponseMeta;
-};
+export type CountryListResult<T extends readonly (keyof Country)[]> =
+  | { success: true; countries: CountryPicker<T>[]; meta: ResponseMeta; error: undefined }
+  | { success: false; countries: undefined; meta: undefined; error: Error };
+
+/**
+ * Discriminated result returned by **single-country** endpoints (including the
+ * not-found case as `success: false`).
+ *
+ * @example
+ * const { success, country, error } = await restCountries.getCountryByCode({ code: "CAN" });
+ * if (!success) throw error;
+ * country; // CountryPicker<T>  (no undefined)
+ */
+export type CountryResult<T extends readonly (keyof Country)[]> =
+  | { success: true; country: CountryPicker<T>; error: undefined }
+  | { success: false; country: undefined; error: Error };
 
 export type SupportedLanguages = (typeof supportedLanguages)[number];
 export type Cca3Code = LiteralUnion<(typeof cca3Codes)[number]>;

--- a/tests/getCountries.test.ts
+++ b/tests/getCountries.test.ts
@@ -2,11 +2,11 @@ import { rc } from "./client";
 
 test("fetches a page of countries with selected fields", async () => {
   const result = await rc.getCountries({ fields: ["names", "area"], limit: 10 });
-  expect(result).not.toBeNull();
-  expect(result!.countries).toHaveLength(10);
-  expect(result!.meta.limit).toBe(10);
-  expect(typeof result!.countries[0].names.common).toBe("string");
-  expect(typeof result!.countries[0].area.kilometers).toBe("number");
+  if (!result.success) throw result.error;
+  expect(result.countries).toHaveLength(10);
+  expect(result.meta.limit).toBe(10);
+  expect(typeof result.countries[0].names.common).toBe("string");
+  expect(typeof result.countries[0].area.kilometers).toBe("number");
 });
 
 test("filters by sovereignty via classification", async () => {
@@ -15,8 +15,8 @@ test("filters by sovereignty via classification", async () => {
     fields: ["classification"],
     limit: 5,
   });
-  expect(result).not.toBeNull();
-  expect(result!.countries.every((c) => c.classification.sovereign === true)).toBe(true);
+  if (!result.success) throw result.error;
+  expect(result.countries.every((c) => c.classification.sovereign === true)).toBe(true);
 });
 
 test("AND-combines composable filters", async () => {
@@ -25,9 +25,9 @@ test("AND-combines composable filters", async () => {
     fields: ["names", "region", "landlocked", "memberships"],
     limit: 100,
   });
-  expect(result).not.toBeNull();
-  expect(result!.countries.length).toBeGreaterThan(0);
-  expect(result!.countries.every((c) => c.region === "Europe" && c.landlocked && c.memberships.eu)).toBe(true);
+  if (!result.success) throw result.error;
+  expect(result.countries.length).toBeGreaterThan(0);
+  expect(result.countries.every((c) => c.region === "Europe" && c.landlocked && c.memberships.eu)).toBe(true);
 });
 
 test("filters by continent and membership", async () => {
@@ -36,13 +36,14 @@ test("filters by continent and membership", async () => {
     fields: ["memberships"],
     limit: 100,
   });
-  expect(result!.countries.every((c) => c.memberships.nato === true)).toBe(true);
+  if (!result.success) throw result.error;
+  expect(result.countries.every((c) => c.memberships.nato === true)).toBe(true);
 });
 
 test("omitFields excludes properties from the response", async () => {
   const result = await rc.getCountries({ omitFields: ["names", "leaders"], limit: 1 });
-  expect(result).not.toBeNull();
-  const country = result!.countries[0] as Record<string, unknown>;
+  if (!result.success) throw result.error;
+  const country = result.countries[0] as Record<string, unknown>;
   expect(country.names).toBeUndefined();
   expect(country.codes).toBeDefined();
 });
@@ -50,5 +51,7 @@ test("omitFields excludes properties from the response", async () => {
 test("honours offset for pagination", async () => {
   const first = await rc.getCountries({ fields: ["names"], limit: 1, offset: 0 });
   const second = await rc.getCountries({ fields: ["names"], limit: 1, offset: 1 });
-  expect(first!.countries[0].names.common).not.toBe(second!.countries[0].names.common);
+  if (!first.success) throw first.error;
+  if (!second.success) throw second.error;
+  expect(first.countries[0].names.common).not.toBe(second.countries[0].names.common);
 });

--- a/tests/getCountriesByCurrency.test.ts
+++ b/tests/getCountriesByCurrency.test.ts
@@ -2,12 +2,12 @@ import { rc } from "./client";
 
 test("fetches countries by currency code", async () => {
   const result = await rc.getCountriesByCurrency({ currency: "EUR", fields: ["names", "currencies"], limit: 100 });
-  expect(result).not.toBeNull();
-  expect(result!.countries.length).toBeGreaterThan(0);
-  expect(result!.countries.some((c) => c.names.common === "Germany")).toBe(true);
+  if (!result.success) throw result.error;
+  expect(result.countries.length).toBeGreaterThan(0);
+  expect(result.countries.some((c) => c.names.common === "Germany")).toBe(true);
 });
 
 test("returns an empty page for an unknown currency", async () => {
   const result = await rc.getCountriesByCurrency({ currency: "ZZZ", fields: ["names"] });
-  expect(result?.countries ?? []).toHaveLength(0);
+  expect(result.success ? result.countries : []).toHaveLength(0);
 });

--- a/tests/getCountriesByLang.test.ts
+++ b/tests/getCountriesByLang.test.ts
@@ -2,11 +2,11 @@ import { rc } from "./client";
 
 test("fetches countries by language", async () => {
   const result = await rc.getCountriesByLang({ lang: "Spanish", fields: ["names", "languages"], limit: 100 });
-  expect(result).not.toBeNull();
-  expect(result!.countries.some((c) => c.names.common === "Spain")).toBe(true);
+  if (!result.success) throw result.error;
+  expect(result.countries.some((c) => c.names.common === "Spain")).toBe(true);
 });
 
 test("returns an empty page for an unknown language", async () => {
   const result = await rc.getCountriesByLang({ lang: "Klingon", fields: ["names"] });
-  expect(result?.countries ?? []).toHaveLength(0);
+  expect(result.success ? result.countries : []).toHaveLength(0);
 });

--- a/tests/getCountriesByName.test.ts
+++ b/tests/getCountriesByName.test.ts
@@ -2,17 +2,18 @@ import { rc } from "./client";
 
 test("fetches countries by partial name", async () => {
   const result = await rc.getCountriesByName({ name: "united", fields: ["names"], limit: 100 });
-  expect(result).not.toBeNull();
-  expect(result!.countries.some((c) => c.names.common === "United Arab Emirates")).toBe(true);
+  if (!result.success) throw result.error;
+  expect(result.countries.some((c) => c.names.common === "United Arab Emirates")).toBe(true);
 });
 
 test("fetches a country by full-text name match", async () => {
   const result = await rc.getCountriesByName({ name: "Finland", fullText: true, fields: ["names"] });
-  expect(result!.countries).toHaveLength(1);
-  expect(result!.countries[0].names.common).toBe("Finland");
+  if (!result.success) throw result.error;
+  expect(result.countries).toHaveLength(1);
+  expect(result.countries[0].names.common).toBe("Finland");
 });
 
 test("returns an empty page for an unknown name", async () => {
   const result = await rc.getCountriesByName({ name: "akskaks", fields: ["names"] });
-  expect(result?.countries ?? []).toHaveLength(0);
+  expect(result.success ? result.countries : []).toHaveLength(0);
 });

--- a/tests/getCountriesByRegion.test.ts
+++ b/tests/getCountriesByRegion.test.ts
@@ -2,12 +2,12 @@ import { rc } from "./client";
 
 test("fetches countries by region", async () => {
   const result = await rc.getCountriesByRegion({ region: "Asia", fields: ["names", "region"], limit: 100 });
-  expect(result).not.toBeNull();
-  expect(result!.countries.every((c) => c.region === "Asia")).toBe(true);
-  expect(result!.countries.some((c) => c.names.common === "Japan")).toBe(true);
+  if (!result.success) throw result.error;
+  expect(result.countries.every((c) => c.region === "Asia")).toBe(true);
+  expect(result.countries.some((c) => c.names.common === "Japan")).toBe(true);
 });
 
 test("returns an empty page for an unknown region", async () => {
   const result = await rc.getCountriesByRegion({ region: "Atlantis" as never, fields: ["names"] });
-  expect(result?.countries ?? []).toHaveLength(0);
+  expect(result.success ? result.countries : []).toHaveLength(0);
 });

--- a/tests/getCountriesBySubregion.test.ts
+++ b/tests/getCountriesBySubregion.test.ts
@@ -1,16 +1,12 @@
 import { rc } from "./client";
 
 test("fetches countries by subregion", async () => {
-  const result = await rc.getCountriesBySubregion({
-    subregion: "Northern Europe",
-    fields: ["names", "subregion"],
-    limit: 100,
-  });
-  expect(result).not.toBeNull();
-  expect(result!.countries.every((c) => c.subregion === "Northern Europe")).toBe(true);
+  const result = await rc.getCountriesBySubregion({ subregion: "Northern Europe", fields: ["names", "subregion"], limit: 100 });
+  if (!result.success) throw result.error;
+  expect(result.countries.every((c) => c.subregion === "Northern Europe")).toBe(true);
 });
 
 test("returns an empty page for an unknown subregion", async () => {
   const result = await rc.getCountriesBySubregion({ subregion: "aaaaaaabbb", fields: ["names"] });
-  expect(result?.countries ?? []).toHaveLength(0);
+  expect(result.success ? result.countries : []).toHaveLength(0);
 });

--- a/tests/getCountryByCapital.test.ts
+++ b/tests/getCountryByCapital.test.ts
@@ -1,12 +1,13 @@
 import { rc } from "./client";
 
 test("fetches a country by capital", async () => {
-  const country = await rc.getCountryByCapital({ capital: "Baku", fields: ["names", "capitals"] });
-  expect(country?.names.common).toBe("Azerbaijan");
-  expect(country?.capitals.some((cap) => cap.name === "Baku")).toBe(true);
+  const result = await rc.getCountryByCapital({ capital: "Baku", fields: ["names", "capitals"] });
+  if (!result.success) throw result.error;
+  expect(result.country.names.common).toBe("Azerbaijan");
+  expect(result.country.capitals.some((cap) => cap.name === "Baku")).toBe(true);
 });
 
-test("returns null for an unknown capital", async () => {
-  const country = await rc.getCountryByCapital({ capital: "ksdsdmkoasl", fields: ["names"] });
-  expect(country).toBeNull();
+test("fails for an unknown capital", async () => {
+  const result = await rc.getCountryByCapital({ capital: "ksdsdmkoasl", fields: ["names"] });
+  expect(result.success).toBe(false);
 });

--- a/tests/getCountryByCode.test.ts
+++ b/tests/getCountryByCode.test.ts
@@ -1,22 +1,32 @@
 import { rc } from "./client";
 
 test("fetches a country by alpha-3 code", async () => {
-  const country = await rc.getCountryByCode({ code: "AZE", fields: ["names", "codes"] });
-  expect(country?.names.common).toBe("Azerbaijan");
-  expect(country?.codes.alpha_3).toBe("AZE");
+  const result = await rc.getCountryByCode({ alpha_3: "AZE", fields: ["names", "codes"] });
+  if (!result.success) throw result.error;
+  expect(result.country.names.common).toBe("Azerbaijan");
+  expect(result.country.codes.alpha_3).toBe("AZE");
 });
 
 test("fetches a country by alpha-2 code", async () => {
-  const country = await rc.getCountryByCode({ code: "AZ", fields: ["codes"] });
-  expect(country?.codes.alpha_2).toBe("AZ");
+  const result = await rc.getCountryByCode({ alpha_2: "AZ", fields: ["codes"] });
+  if (!result.success) throw result.error;
+  expect(result.country.codes.alpha_2).toBe("AZ");
 });
 
-test("resolves a CIOC code via fallback", async () => {
-  const country = await rc.getCountryByCode({ code: "SUI", fields: ["names", "codes"] });
-  expect(country?.names.common).toBe("Switzerland");
+test("fetches a country by ccn3 code", async () => {
+  const result = await rc.getCountryByCode({ ccn3: "031", fields: ["names"] });
+  if (!result.success) throw result.error;
+  expect(result.country.names.common).toBe("Azerbaijan");
 });
 
-test("returns null for an unknown code", async () => {
-  const country = await rc.getCountryByCode({ code: "ZZZ", fields: ["names"] });
-  expect(country).toBeNull();
+test("fetches a country by cioc code", async () => {
+  const result = await rc.getCountryByCode({ cioc: "SUI", fields: ["names"] });
+  if (!result.success) throw result.error;
+  expect(result.country.names.common).toBe("Switzerland");
+});
+
+test("fails for an unknown code", async () => {
+  const result = await rc.getCountryByCode({ alpha_3: "ZZZ", fields: ["names"] });
+  expect(result.success).toBe(false);
+  if (!result.success) expect(result.error).toBeInstanceOf(Error);
 });

--- a/tests/getCountryByDemonym.test.ts
+++ b/tests/getCountryByDemonym.test.ts
@@ -1,11 +1,12 @@
 import { rc } from "./client";
 
 test("fetches a country by demonym", async () => {
-  const country = await rc.getCountryByDemonym({ demonym: "Peruvian", fields: ["names"] });
-  expect(country?.names.common).toBe("Peru");
+  const result = await rc.getCountryByDemonym({ demonym: "Peruvian", fields: ["names"] });
+  if (!result.success) throw result.error;
+  expect(result.country.names.common).toBe("Peru");
 });
 
-test("returns null for an unknown demonym", async () => {
-  const country = await rc.getCountryByDemonym({ demonym: "aaabbbcccc", fields: ["names"] });
-  expect(country).toBeNull();
+test("fails for an unknown demonym", async () => {
+  const result = await rc.getCountryByDemonym({ demonym: "aaabbbcccc", fields: ["names"] });
+  expect(result.success).toBe(false);
 });

--- a/tests/getCountryByTranslation.test.ts
+++ b/tests/getCountryByTranslation.test.ts
@@ -1,11 +1,12 @@
 import { rc } from "./client";
 
 test("fetches a country by translated name", async () => {
-  const country = await rc.getCountryByTranslation({ translation: "Deutschland", fields: ["names"] });
-  expect(country?.names.common).toBe("Germany");
+  const result = await rc.getCountryByTranslation({ translation: "Deutschland", fields: ["names"] });
+  if (!result.success) throw result.error;
+  expect(result.country.names.common).toBe("Germany");
 });
 
-test("returns null for an unknown translation", async () => {
-  const country = await rc.getCountryByTranslation({ translation: "aaabccc", fields: ["names"] });
-  expect(country).toBeNull();
+test("fails for an unknown translation", async () => {
+  const result = await rc.getCountryByTranslation({ translation: "aaabccc", fields: ["names"] });
+  expect(result.success).toBe(false);
 });

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -15,7 +15,7 @@ async function fetchAllCountries(): Promise<Country[]> {
   let offset = 0;
   for (;;) {
     const page = await rc.getCountries({ limit: 100, offset });
-    if (!page) throw new Error(`Failed to fetch countries at offset ${offset}`);
+    if (!page.success) throw page.error;
     all.push(...page.countries);
     if (!page.meta.more) break;
     offset += page.meta.limit;

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -2,13 +2,13 @@ import { rc } from "./client";
 
 test("free-text search finds a country", async () => {
   const result = await rc.search("canada", { fields: ["names"] });
-  expect(result).not.toBeNull();
-  expect(result!.countries.some((c) => c.names.common === "Canada")).toBe(true);
+  if (!result.success) throw result.error;
+  expect(result.countries.some((c) => c.names.common === "Canada")).toBe(true);
 });
 
 test("free-text search combined with a filter", async () => {
   const result = await rc.search("island", { filters: { region: "Oceania" }, fields: ["names", "region"], limit: 100 });
-  expect(result).not.toBeNull();
-  expect(result!.countries.length).toBeGreaterThan(0);
-  expect(result!.countries.every((c) => c.region === "Oceania")).toBe(true);
+  if (!result.success) throw result.error;
+  expect(result.countries.length).toBeGreaterThan(0);
+  expect(result.countries.every((c) => c.region === "Oceania")).toBe(true);
 });


### PR DESCRIPTION
## Summary

See README.md for changes

## Changes

- Updated API client to v5 endpoints with API key validation.
- Refactored response handling for improved type safety.
- Introduced new types for country results.
- Enhanced tests to align with the new response structure.
- Added migration documentation for v4 to v5 changes.

## Checklist

- [x] Ran `pnpm check` locally
- [x] No hardcoded secrets or API keys

