### PR TITLE
Add colors field to flag schema in types and update README

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -436,7 +436,7 @@ The `fields` parameter selects **top-level** properties of `Country` and gives a
 - `names`: common, official, alternates, native and translations
 - `codes`: alpha_2, alpha_3, ccn3, cioc, fifa, fips, gec
 - `capitals`: array of `{ name, coordinates, attributes }`
-- `flag`: description, emoji, html_entity, unicode, url_png, url_svg
+- `flag`: description, emoji, html_entity, unicode, url_png, url_svg, colors (`{ dominant, palette, swatches }`)
 - `region`, `subregion`
 - `area`: `{ kilometers, miles }`
 - `borders`, `calling_codes`, `continents`, `timezones`, `tlds`, `assets`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yusifaliyevpro/countries",
   "description": "TypeScript wrapper for Rest Countries API to fetch country data by codes, capitals, or all countries with full typings.",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -57,6 +57,14 @@ export const countrySchema = z.strictObject({
     }),
   ),
   flag: z.strictObject({
+    colors: z.strictObject({
+      /** Dominant flag color as a hex string. `""` for countries without a flag. */
+      dominant: z.string(),
+      /** Flag color palette as hex strings. `[]` for countries without a flag. */
+      palette: z.array(z.string()),
+      /** Semantic color swatches as a role-to-hex map. `{}` for countries without a flag. */
+      swatches: z.record(z.string(), z.string()),
+    }),
     description: z.string(),
     emoji: z.string(),
     html_entity: z.string(),


### PR DESCRIPTION
## Summary

Add a new `colors` field to the flag schema to include additional color information for flags.

## Changes

- Updated the flag schema to include a `colors` object with properties for dominant color, color palette, and semantic color swatches.
- Modified the README to reflect the changes in the flag schema.

## Checklist

- [x] Ran `pnpm check` locally
- [x] No hardcoded secrets or API keys

